### PR TITLE
Fix maxConcurrent comment

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -11,7 +11,7 @@ const qerrors = require('qerrors');
 // - reservoir: maximum 60 requests per minute
 // - reservoirRefreshInterval: refresh every 60000ms (1 minute)
 // - reservoirRefreshAmount: reset to 60 each interval
-// - maxConcurrent: only one request at a time (serial execution)
+// - maxConcurrent: up to 5 concurrent requests (parallel execution)
 // - minTime: at least 200ms between requests
 const limiter = new Bottleneck({
 	reservoir: 60,


### PR DESCRIPTION
## Summary
- fix comment to match the limiter config

## Testing
- `npm test` *(fails: Cannot find module 'axios')*
- `npm install` *(fails: Exit handler never called)*