### PR TITLE
Create shared environment variable utility

### DIFF
--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -1,0 +1,16 @@
+const qerrors = require('qerrors');
+
+function getMissingEnvVars(varArr) {
+        console.log(`getMissingEnvVars is running with ${varArr}`);
+        try {
+                const missingArr = varArr.filter(name => !process.env[name]);
+                console.log(`getMissingEnvVars returning ${missingArr}`);
+                return missingArr;
+        } catch (error) {
+                qerrors(error, 'getMissingEnvVars error', {varArr});
+                console.log(`getMissingEnvVars returning []`);
+                return [];
+        }
+}
+
+module.exports = { getMissingEnvVars };

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -1,10 +1,11 @@
 const axios = require('axios');
 const Bottleneck = require('bottleneck'); // ADDED: Import Bottleneck for rate limiting
-const apiKey = process.env.GOOGLE_API_KEY;
-const cx = process.env.GOOGLE_CX;
+const apiKey = process.env.GOOGLE_API_KEY; // existing variable
+const cx = process.env.GOOGLE_CX; // existing variable
 // qerrors is used to handle error reporting and logging
 // It requires an OPENAI_TOKEN environment variable to work properly
 const qerrors = require('qerrors');
+const { getMissingEnvVars } = require('./envUtils'); // import env util
 
 
 // ADDED: Create a Bottleneck limiter with desired constraints:
@@ -40,13 +41,11 @@ const rateLimitedRequest = async (url) => {
 };
 
 // Validate required environment variables
-if (!apiKey) {
-  throw new Error('GOOGLE_API_KEY environment variable is required. Get one from https://console.cloud.google.com/');
+const missingVars = getMissingEnvVars(['GOOGLE_API_KEY', 'GOOGLE_CX']); // gather missing vars
+if (missingVars.length > 0) { // check for any missing
+  throw new Error(`Missing environment variables: ${missingVars.join(', ')}`); // throw with combined list
 }
-if (!cx) {
-  throw new Error('GOOGLE_CX environment variable is required. Set up a Custom Search Engine at https://programmablesearchengine.google.com/');
-}
-if (!process.env.OPENAI_TOKEN) {
+if (getMissingEnvVars(['OPENAI_TOKEN']).length > 0) { // warn for logging token
   console.warn('OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.');
 }
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 // Simple test file for qserp module
 const { googleSearch, getTopSearchResults } = require('./index');
+const { getMissingEnvVars } = require('./lib/envUtils'); // reuse env util
 
 async function runTests() {
   console.log('Testing qserp module...');
@@ -36,13 +37,15 @@ async function runTests() {
 }
 
 // Check if environment variables are set before running tests
-if (!process.env.GOOGLE_API_KEY || !process.env.GOOGLE_CX) {
-  console.error('Error: GOOGLE_API_KEY and GOOGLE_CX environment variables must be set to run tests');
+const testVars = ['GOOGLE_API_KEY', 'GOOGLE_CX']; // define required vars
+const missingVars = getMissingEnvVars(testVars); // get missing vars
+if (missingVars.length > 0) { // check for any missing
+  console.error(`Error: Missing required environment variables: ${missingVars.join(', ')}`); // log error
   console.log('Set these in the Secrets tool in Replit before running tests');
   process.exit(1);
 }
 
-if (!process.env.OPENAI_TOKEN) {
+if (getMissingEnvVars(['OPENAI_TOKEN']).length > 0) { // warn about optional token
   console.warn('Warning: OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency.');
   console.log('Consider setting this in the Secrets tool in Replit.');
 }


### PR DESCRIPTION
## Summary
- implement `getMissingEnvVars` utility for environment variable checks
- reuse the new utility in `qserp.js`
- reuse the new utility in `test.js`

## Testing
- `npm test` *(fails: Cannot find module 'axios')*