### PR TITLE
Refactor: centralize env checks

### DIFF
--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -1,16 +1,50 @@
 const qerrors = require('qerrors');
 
 function getMissingEnvVars(varArr) {
-        console.log(`getMissingEnvVars is running with ${varArr}`);
+        console.log(`getMissingEnvVars is running with ${varArr}`); //added log per style
         try {
                 const missingArr = varArr.filter(name => !process.env[name]);
-                console.log(`getMissingEnvVars returning ${missingArr}`);
+                console.log(`getMissingEnvVars returning ${missingArr}`); //current return log
                 return missingArr;
         } catch (error) {
-                qerrors(error, 'getMissingEnvVars error', {varArr});
-                console.log(`getMissingEnvVars returning []`);
+                qerrors(error, 'getMissingEnvVars error', {varArr}); //added qerrors usage
+                console.log(`getMissingEnvVars returning []`); //return on error
                 return [];
         }
 }
 
-module.exports = { getMissingEnvVars };
+function throwIfMissingEnvVars(varArr) {
+        console.log(`throwIfMissingEnvVars is running with ${varArr}`); //added start log
+        try {
+                const missingArr = getMissingEnvVars(varArr);
+                if (missingArr.length > 0) {
+                        console.log(`throwIfMissingEnvVars has run resulting in a final value of ${missingArr}`); //log before throw
+                        throw new Error(`Missing environment variables: ${missingArr.join(', ')}`);
+                }
+                console.log(`throwIfMissingEnvVars returning []`); //no vars missing
+                return [];
+        } catch (error) {
+                qerrors(error, 'throwIfMissingEnvVars error', {varArr}); //error logging
+                console.log(`throwIfMissingEnvVars returning []`); //return on error
+                return [];
+        }
+}
+
+function warnIfMissingEnvVars(varArr, warnMsg) {
+        console.log(`warnIfMissingEnvVars is running with ${varArr}`); //start log
+        try {
+                if (getMissingEnvVars(varArr).length > 0) {
+                        console.warn(warnMsg);
+                        console.log(`warnIfMissingEnvVars returning false`); //warn issued
+                        return false;
+                }
+                console.log(`warnIfMissingEnvVars returning true`); //no warning
+                return true;
+        } catch (error) {
+                qerrors(error, 'warnIfMissingEnvVars error', {varArr, warnMsg}); //error logging
+                console.log(`warnIfMissingEnvVars returning false`); //return on error
+                return false;
+        }
+}
+
+module.exports = { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars };

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -5,7 +5,7 @@ const cx = process.env.GOOGLE_CX; // existing variable
 // qerrors is used to handle error reporting and logging
 // It requires an OPENAI_TOKEN environment variable to work properly
 const qerrors = require('qerrors');
-const { getMissingEnvVars } = require('./envUtils'); // import env util
+const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('./envUtils'); // import env utils
 
 
 // ADDED: Create a Bottleneck limiter with desired constraints:
@@ -40,14 +40,9 @@ const rateLimitedRequest = async (url) => {
 	);
 };
 
-// Validate required environment variables
-const missingVars = getMissingEnvVars(['GOOGLE_API_KEY', 'GOOGLE_CX']); // gather missing vars
-if (missingVars.length > 0) { // check for any missing
-  throw new Error(`Missing environment variables: ${missingVars.join(', ')}`); // throw with combined list
-}
-if (getMissingEnvVars(['OPENAI_TOKEN']).length > 0) { // warn for logging token
-  console.warn('OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.');
-}
+// Validate required environment variables using util
+throwIfMissingEnvVars(['GOOGLE_API_KEY', 'GOOGLE_CX']); // ensure API key and CX exist
+warnIfMissingEnvVars(['OPENAI_TOKEN'], 'OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.'); // warn if optional token missing
 
 
 /**

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 // Simple test file for qserp module
 const { googleSearch, getTopSearchResults } = require('./index');
-const { getMissingEnvVars } = require('./lib/envUtils'); // reuse env util
+const { getMissingEnvVars, warnIfMissingEnvVars } = require('./lib/envUtils'); // reuse env utils
 
 async function runTests() {
   console.log('Testing qserp module...');
@@ -45,9 +45,6 @@ if (missingVars.length > 0) { // check for any missing
   process.exit(1);
 }
 
-if (getMissingEnvVars(['OPENAI_TOKEN']).length > 0) { // warn about optional token
-  console.warn('Warning: OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency.');
-  console.log('Consider setting this in the Secrets tool in Replit.');
-}
+warnIfMissingEnvVars(['OPENAI_TOKEN'], 'Warning: OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency.'); // ADDED util warning
 
 runTests();


### PR DESCRIPTION
## Summary
- create `throwIfMissingEnvVars` and `warnIfMissingEnvVars` helpers
- reuse new utilities in `qserp.js`
- reuse warning util in tests

## Testing
- `npm test` *(fails: Cannot find module 'axios')*