### PR TITLE
Add constants module for env vars

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,4 @@
+const REQUIRED_VARS = ['GOOGLE_API_KEY', 'GOOGLE_CX']; //define required env vars
+const OPTIONAL_VARS = ['OPENAI_TOKEN']; //define optional env vars
+
+module.exports = { REQUIRED_VARS, OPTIONAL_VARS }; //export variables

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -6,6 +6,7 @@ const cx = process.env.GOOGLE_CX; // existing variable
 // It requires an OPENAI_TOKEN environment variable to work properly
 const qerrors = require('qerrors');
 const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('./envUtils'); // import env utils
+const { REQUIRED_VARS, OPTIONAL_VARS } = require('./constants'); //import env constants
 
 
 // ADDED: Create a Bottleneck limiter with desired constraints:
@@ -41,8 +42,8 @@ const rateLimitedRequest = async (url) => {
 };
 
 // Validate required environment variables using util
-throwIfMissingEnvVars(['GOOGLE_API_KEY', 'GOOGLE_CX']); // ensure API key and CX exist
-warnIfMissingEnvVars(['OPENAI_TOKEN'], 'OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.'); // warn if optional token missing
+throwIfMissingEnvVars(REQUIRED_VARS); //ensure API key and CX exist
+warnIfMissingEnvVars(OPTIONAL_VARS, 'OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.'); //warn if optional token missing
 
 
 /**

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 // Simple test file for qserp module
 const { googleSearch, getTopSearchResults } = require('./index');
 const { getMissingEnvVars, warnIfMissingEnvVars } = require('./lib/envUtils'); // reuse env utils
+const { REQUIRED_VARS, OPTIONAL_VARS } = require('./lib/constants'); //import env constants
 
 async function runTests() {
   console.log('Testing qserp module...');
@@ -37,14 +38,14 @@ async function runTests() {
 }
 
 // Check if environment variables are set before running tests
-const testVars = ['GOOGLE_API_KEY', 'GOOGLE_CX']; // define required vars
-const missingVars = getMissingEnvVars(testVars); // get missing vars
+const testVars = REQUIRED_VARS; //define required vars
+const missingVars = getMissingEnvVars(testVars); //get missing vars
 if (missingVars.length > 0) { // check for any missing
   console.error(`Error: Missing required environment variables: ${missingVars.join(', ')}`); // log error
   console.log('Set these in the Secrets tool in Replit before running tests');
   process.exit(1);
 }
 
-warnIfMissingEnvVars(['OPENAI_TOKEN'], 'Warning: OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency.'); // ADDED util warning
+warnIfMissingEnvVars(OPTIONAL_VARS, 'Warning: OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency.'); //use constants for warn
 
 runTests();


### PR DESCRIPTION
## Summary
- add constants module for env var names
- update `lib/qserp.js` to use new constants
- use constants in test helper

## Testing
- `npm test` *(fails: Cannot find module 'axios')*