### PR TITLE
Add jest tests for qserp

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Module for search engine search functions and performing Google custom searches using the Google API.",
   "main": "index.js",
   "scripts": {
-    "test": "node test.js"
+    "test": "jest"
   },
   "keywords": [
     "google",
@@ -19,6 +19,10 @@
     "axios": "^1.2.0",
     "bottleneck": "^2.19.5",
     "qerrors": "^1.1.7"
+  },
+  "devDependencies": {
+    "axios-mock-adapter": "^1.21.2",
+    "jest": "^29.6.0"
   },
   "directories": {
     "lib": "lib"

--- a/test/qserp.test.js
+++ b/test/qserp.test.js
@@ -1,0 +1,57 @@
+const MockAdapter = require('axios-mock-adapter');
+const axios = require('axios');
+
+process.env.GOOGLE_API_KEY = 'key';
+process.env.GOOGLE_CX = 'cx';
+process.env.OPENAI_TOKEN = 'token';
+
+const scheduleMock = jest.fn(fn => Promise.resolve(fn()));
+jest.mock('bottleneck', () => jest.fn().mockImplementation(() => ({ schedule: scheduleMock })));
+
+const qerrorsMock = jest.fn();
+jest.mock('qerrors', () => (...args) => qerrorsMock(...args));
+
+const { googleSearch, getTopSearchResults } = require('../lib/qserp');
+
+const mock = new MockAdapter(axios);
+
+describe('qserp module', () => {
+  beforeEach(() => {
+    mock.reset();
+    scheduleMock.mockClear();
+    qerrorsMock.mockClear();
+  });
+
+  test('googleSearch returns parsed results', async () => {
+    mock.onGet(/customsearch/).reply(200, {
+      items: [{ title: 'A', snippet: 'B', link: 'C' }]
+    });
+    const results = await googleSearch('hi');
+    expect(results).toEqual([{ title: 'A', snippet: 'B', link: 'C' }]);
+    expect(scheduleMock).toHaveBeenCalled();
+  });
+
+  test('getTopSearchResults returns top links', async () => {
+    mock.onGet(/Java/).reply(200, { items: [{ link: 'http://j' }] });
+    mock.onGet(/Python/).reply(200, { items: [{ link: 'http://p' }] });
+    const urls = await getTopSearchResults(['Java', 'Python']);
+    expect(urls).toEqual(['http://j', 'http://p']);
+    expect(scheduleMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('handles empty or invalid input', async () => {
+    await expect(googleSearch('')).rejects.toThrow();
+    await expect(getTopSearchResults('bad')).rejects.toThrow();
+    const emptyUrls = await getTopSearchResults([]);
+    expect(emptyUrls).toEqual([]);
+  });
+
+  test('logs errors via helper on request failure', async () => {
+    mock.onGet(/customsearch/).reply(500);
+    const res = await googleSearch('err');
+    const urls = await getTopSearchResults(['err']);
+    expect(res).toEqual([]);
+    expect(urls).toEqual([]);
+    expect(qerrorsMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add jest-based unit tests using axios-mock-adapter
- add dev dependencies for jest testing

## Testing
- `npm test` *(fails: jest not found)*