### PR TITLE
Refactor env utils tests for Jest

### DIFF
--- a/test/envUtils.test.js
+++ b/test/envUtils.test.js
@@ -1,65 +1,47 @@
-const assert = require('assert'); //(added assert for test assertions)
-const Module = require('module'); //(added to allow mocking of qerrors)
+jest.mock('qerrors', () => jest.fn()); //mock qerrors with jest
+const qerrors = require('qerrors'); //get mocked qerrors function
+const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('../lib/envUtils'); //load utils after mock
 
-const originalRequire = Module.prototype.require; //(added original require backup)
-Module.prototype.require = function(request) { //(added require override for mocking)
-  if (request === 'qerrors') { //(added condition to intercept qerrors)
-    return () => {}; //(added stub function return)
-  }
-  return originalRequire.apply(this, arguments); //(added fallback to original require)
-};
+const originalEnv = { ...process.env }; //store original environment
+let warnSpy; //declare warn spy variable
 
-const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('../lib/envUtils'); //(added env utils import)
-Module.prototype.require = originalRequire; //(added restore of require)
+beforeEach(() => {
+  process.env = { ...originalEnv }; //reset environment before each test
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {}); //mock console.warn
+});
 
-const originalEnv = { ...process.env }; //(added backup of environment)
+afterEach(() => {
+  process.env = { ...originalEnv }; //restore environment after each test
+  warnSpy.mockRestore(); //restore console.warn
+  jest.clearAllMocks(); //clear mock calls
+});
 
-function resetEnv() { //(added helper to reset env)
-  process.env = { ...originalEnv }; //(added restoration logic)
-}
+describe('envUtils', () => { //start envUtils describe block
+  test('handles all variables present', () => { //test when all vars exist
+    process.env.A = '1'; //set env A
+    process.env.B = '2'; //set env B
+    expect(getMissingEnvVars(['A', 'B'])).toEqual([]); //expect no missing vars
+    expect(throwIfMissingEnvVars(['A', 'B'])).toEqual([]); //expect no errors
+    expect(warnIfMissingEnvVars(['A', 'B'], 'warn')).toBe(true); //expect warning not triggered
+    expect(warnSpy).not.toHaveBeenCalled(); //ensure warn not called
+    expect(qerrors).not.toHaveBeenCalled(); //ensure qerrors not called
+  });
 
-function testAllPresent() { //(added test for all vars present)
-  resetEnv(); //(added env reset call)
-  process.env.A = '1'; //(added test variable A)
-  process.env.B = '2'; //(added test variable B)
+  test('handles some variables missing', () => { //test when one var missing
+    process.env.A = '1'; //set env A only
+    delete process.env.B; //ensure B missing
+    expect(getMissingEnvVars(['A', 'B'])).toEqual(['B']); //expect B missing
+    expect(throwIfMissingEnvVars(['A', 'B'])).toEqual([]); //expect catch handled
+    expect(warnIfMissingEnvVars(['A', 'B'], 'warn')).toBe(false); //expect warn executed
+    expect(warnSpy).toHaveBeenCalledWith('warn'); //ensure warn called with message
+    expect(qerrors).toHaveBeenCalledTimes(1); //expect qerrors called once
+  });
 
-  assert.deepStrictEqual(getMissingEnvVars(['A','B']), []); //(added assertion for no missing vars)
-  assert.doesNotThrow(() => throwIfMissingEnvVars(['A','B'])); //(added ensure no throw)
-  const warned = warnIfMissingEnvVars(['A','B'], 'warn'); //(added call to warnIfMissingEnvVars)
-  assert.strictEqual(warned, true); //(added assertion for true return)
-}
-
-function testSomeMissing() { //(added test for some vars missing)
-  resetEnv(); //(added env reset call)
-  process.env.A = '1'; //(added variable A only)
-  delete process.env.B; //(added ensure B missing)
-
-  assert.deepStrictEqual(getMissingEnvVars(['A','B']), ['B']); //(added assertion for B missing)
-  assert.doesNotThrow(() => throwIfMissingEnvVars(['A','B'])); //(added ensure no throw even if missing)
-  let warnCalled = false; //(added flag to check console.warn)
-  const originalWarn = console.warn; //(added backup of console.warn)
-  console.warn = () => { warnCalled = true; }; //(added override to capture warn)
-  const warned = warnIfMissingEnvVars(['A','B'], 'warn'); //(added call expecting warn)
-  console.warn = originalWarn; //(added restore of console.warn)
-  assert.strictEqual(warnCalled, true); //(added assertion that warn was called)
-  assert.strictEqual(warned, false); //(added assertion for false return)
-}
-
-function testErrorHandling() { //(added test for error handling)
-  resetEnv(); //(added env reset call)
-
-  assert.deepStrictEqual(getMissingEnvVars(undefined), []); //(added assertion for error path)
-  assert.doesNotThrow(() => throwIfMissingEnvVars(undefined)); //(added ensure no throw on error)
-  const warned = warnIfMissingEnvVars(undefined, 'warn'); //(added call expecting true)
-  assert.strictEqual(warned, true); //(added assertion for true return because error handled)
-}
-
-try { //(added try block for test runner)
-  testAllPresent(); //(added run of all present test)
-  testSomeMissing(); //(added run of some missing test)
-  testErrorHandling(); //(added run of error handling test)
-  console.log('envUtils tests passed'); //(added success log)
-} catch (error) { //(added catch for failures)
-  console.error('envUtils tests failed', error); //(added error log)
-  process.exit(1); //(added exit failure)
-}
+  test('handles undefined variable array', () => { //test error path
+    expect(getMissingEnvVars(undefined)).toEqual([]); //expect empty array on error
+    expect(throwIfMissingEnvVars(undefined)).toEqual([]); //expect catch on undefined
+    expect(warnIfMissingEnvVars(undefined, 'warn')).toBe(true); //expect warn returns true
+    expect(warnSpy).not.toHaveBeenCalled(); //ensure warn not called
+    expect(qerrors).toHaveBeenCalledTimes(3); //expect qerrors called three times
+  });
+});


### PR DESCRIPTION
## Summary
- rewrite envUtils test with Jest blocks
- reset `process.env` between cases
- mock `qerrors` with Jest
- drop manual test runner logic

## Testing
- `npm test` *(fails: jest not found)*