### PR TITLE
Add export validation test

### DIFF
--- a/__tests__/indexExport.test.js
+++ b/__tests__/indexExport.test.js
@@ -1,0 +1,9 @@
+const indexExports = require('../index'); //(import index module to test re-export)
+const libExports = require('../lib/qserp'); //(import direct lib module)
+
+test('index exports match lib exports', () => { //(test equality)
+  expect(Object.keys(indexExports)).toEqual(Object.keys(libExports)); //(confirm same keys)
+  Object.keys(libExports).forEach(key => {
+    expect(indexExports[key]).toBe(libExports[key]); //(ensure same references)
+  });
+});


### PR DESCRIPTION
## Summary
- test that index.js re-exports all functions from lib/qserp

## Testing
- `npm test` *(fails: jest not found)*