### PR TITLE
Refactor test setup helpers

### DIFF
--- a/__tests__/integrationCombined.test.js
+++ b/__tests__/integrationCombined.test.js
@@ -1,19 +1,12 @@
-const MockAdapter = require('axios-mock-adapter'); //setup axios mock adapter
-const axios = require('axios'); //import axios for mocking
+const { setTestEnv, createScheduleMock, createQerrorsMock, createAxiosMock } = require('./utils/testSetup'); //load shared helpers
 
-process.env.GOOGLE_API_KEY = 'key'; //set fake google api key
-process.env.GOOGLE_CX = 'cx'; //set fake google cx id
-process.env.OPENAI_TOKEN = 'token'; //set fake openai token
+setTestEnv(); //set env vars for tests
+const scheduleMock = createScheduleMock(); //mock bottleneck schedule
+const qerrorsMock = createQerrorsMock(); //mock qerrors
 
-const scheduleMock = jest.fn(fn => Promise.resolve(fn())); //mock bottleneck schedule
-jest.mock('bottleneck', () => jest.fn().mockImplementation(() => ({ schedule: scheduleMock }))); //mock Bottleneck constructor
-
-const qerrorsMock = jest.fn(); //mock qerrors logging
-jest.mock('qerrors', () => (...args) => qerrorsMock(...args)); //replace qerrors with mock
+const mock = createAxiosMock(); //axios mock adapter instance
 
 const { googleSearch, getTopSearchResults } = require('../lib/qserp'); //load functions under test
-
-const mock = new MockAdapter(axios); //create axios mock instance
 
 describe('integration googleSearch and getTopSearchResults', () => { //describe block
   beforeEach(() => { //reset mocks

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -1,17 +1,12 @@
 const axios = require('axios');
+const { setTestEnv, createScheduleMock, createQerrorsMock } = require('./utils/testSetup'); //import helpers
 
-// mocks and env setup
-process.env.GOOGLE_API_KEY = 'key';
-process.env.GOOGLE_CX = 'cx';
-process.env.OPENAI_TOKEN = 'tkn';
+setTestEnv(); //set up env vars
+const scheduleMock = createScheduleMock(); //mock Bottleneck
 
-const scheduleMock = jest.fn(fn => Promise.resolve(fn()));
-jest.mock('bottleneck', () => jest.fn().mockImplementation(() => ({ schedule: scheduleMock })));
+jest.mock('axios'); //mock axios module
 
-jest.mock('axios');
-
-const qerrorsMock = jest.fn();
-jest.mock('qerrors', () => (...args) => qerrorsMock(...args));
+const qerrorsMock = createQerrorsMock(); //mock qerrors
 
 beforeEach(() => {
   jest.resetModules();

--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -1,19 +1,12 @@
-const MockAdapter = require('axios-mock-adapter'); //import mock adapter for axios
-const axios = require('axios'); //import axios for requests
+const { setTestEnv, createScheduleMock, createQerrorsMock, createAxiosMock } = require('./utils/testSetup'); //load shared test helpers
 
-process.env.GOOGLE_API_KEY = 'key'; //set mock api key for tests
-process.env.GOOGLE_CX = 'cx'; //set mock custom search id for tests
-process.env.OPENAI_TOKEN = 'token'; //set mock openai token for qerrors
+setTestEnv(); //initialize common env vars
+const scheduleMock = createScheduleMock(); //setup bottleneck mock
+const qerrorsMock = createQerrorsMock(); //setup qerrors mock
 
-const scheduleMock = jest.fn(fn => Promise.resolve(fn())); //create bottleneck schedule mock
-jest.mock('bottleneck', () => jest.fn().mockImplementation(() => ({ schedule: scheduleMock }))); //mock bottleneck to use schedule mock
-
-const qerrorsMock = jest.fn(); //create qerrors mock function
-jest.mock('qerrors', () => (...args) => qerrorsMock(...args)); //mock qerrors module
+const mock = createAxiosMock(); //setup axios mock adapter
 
 const { googleSearch, getTopSearchResults } = require('../lib/qserp'); //load functions under test from library
-
-const mock = new MockAdapter(axios); //create axios mock adapter instance
 
 describe('qserp module', () => { //group qserp tests
   beforeEach(() => { //reset mocks before each test

--- a/__tests__/utils/testSetup.js
+++ b/__tests__/utils/testSetup.js
@@ -1,0 +1,36 @@
+function setTestEnv() {
+  console.log(`setTestEnv is running with default values`); //initial log
+  process.env.GOOGLE_API_KEY = 'key'; //set common api key
+  process.env.GOOGLE_CX = 'cx'; //set common cx id
+  process.env.OPENAI_TOKEN = 'token'; //set common openai token
+  console.log(`setTestEnv returning true`); //final log
+  return true; //confirm env set
+}
+
+function createScheduleMock() {
+  console.log(`createScheduleMock is running with none`); //initial log
+  const scheduleMock = jest.fn(fn => Promise.resolve(fn())); //mock schedule fn
+  jest.mock('bottleneck', () => jest.fn().mockImplementation(() => ({ schedule: scheduleMock }))); //mock bottleneck
+  console.log(`createScheduleMock returning mock`); //final log
+  return scheduleMock; //export schedule mock
+}
+
+function createQerrorsMock() {
+  console.log(`createQerrorsMock is running with none`); //initial log
+  const qerrorsMock = jest.fn(); //mock qerrors fn
+  jest.mock('qerrors', () => (...args) => qerrorsMock(...args)); //mock qerrors
+  console.log(`createQerrorsMock returning mock`); //final log
+  return qerrorsMock; //export qerrors mock
+}
+
+function createAxiosMock() {
+  console.log(`createAxiosMock is running with none`); //initial log
+  const MockAdapter = require('axios-mock-adapter'); //import mock adapter
+  const axios = require('axios'); //import axios instance
+  const mock = new MockAdapter(axios); //create adapter instance
+  console.log(`createAxiosMock returning adapter`); //final log
+  return mock; //export axios mock
+}
+
+module.exports = { setTestEnv, createScheduleMock, createQerrorsMock, createAxiosMock }; //export helpers
+


### PR DESCRIPTION
## Summary
- centralize mocked environment & dependencies in `testSetup`
- use helpers across qserp tests

## Testing
- `npm test` *(fails: jest not found)*