### PR TITLE
Refactor test setup

### DIFF
--- a/__tests__/integrationCombined.test.js
+++ b/__tests__/integrationCombined.test.js
@@ -11,15 +11,15 @@ jest.mock('bottleneck', () => jest.fn().mockImplementation(() => ({ schedule: sc
 const qerrorsMock = jest.fn(); //mock qerrors logging
 jest.mock('qerrors', () => (...args) => qerrorsMock(...args)); //replace qerrors with mock
 
+const { resetTestMocks } = require('./utils/testSetup'); //import helper to reset mocks
+
 const { googleSearch, getTopSearchResults } = require('../lib/qserp'); //load functions under test
 
 const mock = new MockAdapter(axios); //create axios mock instance
 
 describe('integration googleSearch and getTopSearchResults', () => { //describe block
   beforeEach(() => { //reset mocks
-    mock.reset(); //reset axios mock
-    scheduleMock.mockClear(); //clear schedule calls
-    qerrorsMock.mockClear(); //clear qerrors calls
+    resetTestMocks(mock, scheduleMock, qerrorsMock); //invoke shared reset helper
   });
 
   test('multiple terms return arrays of urls and schedule invoked per request', async () => { //success path test

--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -11,15 +11,15 @@ jest.mock('bottleneck', () => jest.fn().mockImplementation(() => ({ schedule: sc
 const qerrorsMock = jest.fn(); //create qerrors mock function
 jest.mock('qerrors', () => (...args) => qerrorsMock(...args)); //mock qerrors module
 
+const { resetTestMocks } = require('./utils/testSetup'); //import helper to reset mocks
+
 const { googleSearch, getTopSearchResults } = require('../lib/qserp'); //load functions under test from library
 
 const mock = new MockAdapter(axios); //create axios mock adapter instance
 
 describe('qserp module', () => { //group qserp tests
   beforeEach(() => { //reset mocks before each test
-    mock.reset(); //clear axios mock history
-    scheduleMock.mockClear(); //clear bottleneck schedule mock
-    qerrorsMock.mockClear(); //clear qerrors mock history
+    resetTestMocks(mock, scheduleMock, qerrorsMock); //invoke shared reset helper
   });
 
   test('googleSearch returns parsed results', async () => { //verify googleSearch formatting

--- a/__tests__/utils/testSetup.js
+++ b/__tests__/utils/testSetup.js
@@ -1,0 +1,16 @@
+function resetTestMocks(mock, scheduleMock, qerrorsMock){ //(utility to reset mocks across tests)
+  console.log(`resetTestMocks is running with ${mock},${scheduleMock},${qerrorsMock}`); //(start log for helper)
+  try{ //(open try block)
+    if(mock && typeof mock.reset === 'function'){ mock.reset(); } //(reset axios mock if provided)
+    if(scheduleMock && typeof scheduleMock.mockClear === 'function'){ scheduleMock.mockClear(); } //(clear schedule mock)
+    if(qerrorsMock && typeof qerrorsMock.mockClear === 'function'){ qerrorsMock.mockClear(); } //(clear qerrors mock)
+    console.log(`resetTestMocks is returning true`); //(log success)
+    return true; //(confirm operation success)
+  }catch(err){ //(catch errors during reset)
+    console.error(err); //(output caught error)
+    console.log(`resetTestMocks returning false`); //(log failure)
+    return false; //(confirm failure)
+  }
+}
+
+module.exports = { resetTestMocks }; //(export helper function)


### PR DESCRIPTION
## Summary
- centralize resetting of test mocks into a new helper
- reuse the helper in qserp tests
- reuse the helper in integration tests

## Testing
- `npx jest` *(fails: request to https://registry.npmjs.org/jest failed)*