### PR TITLE
Add generic safeRun utility

### DIFF
--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -1,16 +1,10 @@
-const qerrors = require('qerrors');
+const { safeRun } = require('./utils'); //import shared safeRun utility
 
-function safeEnvCall(fnName, fn, defaultVal, context) { //(introduce central helper for env calls)
-        console.log(`${fnName} is running with ${context.varArr}`); //(initial log with variables)
-        try { //(start protected execution)
-                const result = fn(); //(execute provided logic)
-                console.log(`${fnName} returning ${result}`); //(log result before return)
-                return result; //(return successful result)
-        } catch (error) { //(handle any error)
-                qerrors(error, `${fnName} error`, context); //(log error context)
-                console.log(`${fnName} returning ${defaultVal}`); //(log fallback value)
-                return defaultVal; //(return fallback)
-        }
+function safeEnvCall(fnName, fn, defaultVal, context) { //(wrap env calls safely)
+        console.log(`safeEnvCall is running with ${fnName}`); //(initial log for wrapper)
+        const res = safeRun(fnName, fn, defaultVal, context); //(use shared utility)
+        console.log(`safeEnvCall returning ${res}`); //(log final result)
+        return res; //(return result from safeRun)
 }
 
 function getMissingEnvVars(varArr) {

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -5,6 +5,7 @@ const cx = process.env.GOOGLE_CX; // existing variable
 // qerrors is used to handle error reporting and logging
 // It requires an OPENAI_TOKEN environment variable to work properly
 const qerrors = require('qerrors');
+const { safeRun } = require('./utils'); //import shared safeRun utility
 const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('./envUtils'); // import env utils
 const { REQUIRED_VARS, OPTIONAL_VARS } = require('./constants'); //import env constants
 
@@ -57,22 +58,19 @@ function getGoogleURL(query) {
         return `https://www.googleapis.com/customsearch/v1?q=${encodeURIComponent(query)}&key=${apiKey}&cx=${cx}`;
 }
 
-function handleAxiosError(error, contextMsg) { //ADDED helper for axios errors
+function handleAxiosError(error, contextMsg) { //central axios error handler
         console.log(`handleAxiosError is running with ${contextMsg}`); //start log
-        try { //start try
+        const res = safeRun('handleAxiosError', () => { //use safeRun wrapper
                 if (error.response) { //check for response
                         console.error(error.response); //log response object
                 } else { //no response
                         console.error(error.message); //log error message
                 }
                 qerrors(error, contextMsg, {contextMsg}); //central error handling
-                console.log(`handleAxiosError returning true`); //final log
                 return true; //confirm handled
-        } catch (err) { //error in handler
-                qerrors(err, 'handleAxiosError error', {contextMsg}); //log internal error
-                console.log(`handleAxiosError returning false`); //fail log
-                return false; //confirm failure
-        }
+        }, false, {contextMsg});
+        console.log(`handleAxiosError returning ${res}`); //final log
+        return res; //return result
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,16 @@
+const qerrors = require('qerrors'); //import qerrors for error handling
+
+function safeRun(fnName, fn, defaultVal, context) { //add shared safe executor
+        console.log(`safeRun is running with ${JSON.stringify({fnName, context})}`); //log input
+        try { //begin try
+                const result = fn(); //execute callback
+                console.log(`safeRun returning ${result}`); //log result
+                return result; //return successful result
+        } catch (error) { //catch errors
+                qerrors(error, `${fnName} error`, context); //report with qerrors
+                console.log(`safeRun returning ${defaultVal}`); //log fallback
+                return defaultVal; //return fallback value
+        }
+}
+
+module.exports = { safeRun }; //export utility


### PR DESCRIPTION
## Summary
- add `safeRun` utility for qerrors and logging
- call `safeRun` from env utils and axios error handler

## Testing
- `npm test` *(fails: jest not found)*