### PR TITLE
Improve test setup helpers

### DIFF
--- a/__tests__/integrationCombined.test.js
+++ b/__tests__/integrationCombined.test.js
@@ -1,18 +1,12 @@
-const { setTestEnv, createScheduleMock, createQerrorsMock, createAxiosMock } = require('./utils/testSetup'); //load shared helpers
+const { initSearchTest, resetMocks } = require('./utils/testSetup'); //use new helpers
 
-setTestEnv(); //set env vars for tests
-const scheduleMock = createScheduleMock(); //mock bottleneck schedule
-const qerrorsMock = createQerrorsMock(); //mock qerrors
-
-const mock = createAxiosMock(); //axios mock adapter instance
+const { mock, scheduleMock, qerrorsMock } = initSearchTest(); //init environment and mocks
 
 const { googleSearch, getTopSearchResults } = require('../lib/qserp'); //load functions under test
 
 describe('integration googleSearch and getTopSearchResults', () => { //describe block
   beforeEach(() => { //reset mocks
-    mock.reset(); //reset axios mock
-    scheduleMock.mockClear(); //clear schedule calls
-    qerrorsMock.mockClear(); //clear qerrors calls
+    resetMocks(mock, scheduleMock, qerrorsMock); //use helper to clear mocks
   });
 
   test('multiple terms return arrays of urls and schedule invoked per request', async () => { //success path test

--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -1,18 +1,12 @@
-const { setTestEnv, createScheduleMock, createQerrorsMock, createAxiosMock } = require('./utils/testSetup'); //load shared test helpers
+const { initSearchTest, resetMocks } = require('./utils/testSetup'); //use new helpers
 
-setTestEnv(); //initialize common env vars
-const scheduleMock = createScheduleMock(); //setup bottleneck mock
-const qerrorsMock = createQerrorsMock(); //setup qerrors mock
-
-const mock = createAxiosMock(); //setup axios mock adapter
+const { mock, scheduleMock, qerrorsMock } = initSearchTest(); //initialize env and mocks
 
 const { googleSearch, getTopSearchResults } = require('../lib/qserp'); //load functions under test from library
 
 describe('qserp module', () => { //group qserp tests
   beforeEach(() => { //reset mocks before each test
-    mock.reset(); //clear axios mock history
-    scheduleMock.mockClear(); //clear bottleneck schedule mock
-    qerrorsMock.mockClear(); //clear qerrors mock history
+    resetMocks(mock, scheduleMock, qerrorsMock); //use helper to clear mocks
   });
 
   test('googleSearch returns parsed results', async () => { //verify googleSearch formatting

--- a/__tests__/utils/testSetup.js
+++ b/__tests__/utils/testSetup.js
@@ -32,5 +32,24 @@ function createAxiosMock() {
   return mock; //export axios mock
 }
 
-module.exports = { setTestEnv, createScheduleMock, createQerrorsMock, createAxiosMock }; //export helpers
+function resetMocks(mock, scheduleMock, qerrorsMock) { //helper to clear mocks
+  console.log(`resetMocks is running with mocks`); //initial log
+  mock.reset(); //clear axios mock history
+  scheduleMock.mockClear(); //clear Bottleneck schedule calls
+  qerrorsMock.mockClear(); //clear qerrors call history
+  console.log(`resetMocks returning true`); //final log
+  return true; //confirm reset
+}
+
+function initSearchTest() { //helper to init env and mocks
+  console.log(`initSearchTest is running with none`); //initial log
+  setTestEnv(); //prepare environment variables
+  const scheduleMock = createScheduleMock(); //create schedule mock
+  const qerrorsMock = createQerrorsMock(); //create qerrors mock
+  const mock = createAxiosMock(); //create axios mock
+  console.log(`initSearchTest returning mocks`); //final log
+  return { mock, scheduleMock, qerrorsMock }; //return configured mocks
+}
+
+module.exports = { setTestEnv, createScheduleMock, createQerrorsMock, createAxiosMock, resetMocks, initSearchTest }; //export helpers
 


### PR DESCRIPTION
## Summary
- expand utils/testSetup.js with resetMocks and initSearchTest helpers
- use new helpers in qserp.test.js
- use new helpers in integrationCombined.test.js

## Testing
- `npm test` *(fails: jest not found)*