### PR TITLE
Add fetchSearchItems helper

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -32,6 +32,14 @@ test('rateLimitedRequest rejects on axios failure and schedules call', async () 
   expect(scheduleMock).toHaveBeenCalled(); //ensure schedule invoked despite rejection
 });
 
+test('fetchSearchItems returns items and schedules call', async () => { //new helper test
+  axios.get.mockResolvedValue({ data: { items: [{ link: 'x' }] } }); //mock success
+  const { fetchSearchItems } = require('../lib/qserp'); //load helper
+  const items = await fetchSearchItems('term'); //invoke helper
+  expect(items).toEqual([{ link: 'x' }]); //check items array
+  expect(scheduleMock).toHaveBeenCalled(); //ensure schedule used
+});
+
 test('getGoogleURL builds proper url', () => {
   const { getGoogleURL } = require('../lib/qserp');
   const url = getGoogleURL('hello world');

--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -2,7 +2,7 @@ const { initSearchTest, resetMocks } = require('./utils/testSetup'); //use new h
 
 const { mock, scheduleMock, qerrorsMock } = initSearchTest(); //initialize env and mocks
 
-const { googleSearch, getTopSearchResults } = require('../lib/qserp'); //load functions under test from library
+const { googleSearch, getTopSearchResults, fetchSearchItems } = require('../lib/qserp'); //load functions under test from library
 
 describe('qserp module', () => { //group qserp tests
   beforeEach(() => { //reset mocks before each test
@@ -23,6 +23,13 @@ describe('qserp module', () => { //group qserp tests
     const results = await googleSearch('none'); //perform search expecting empty
     expect(results).toEqual([]); //should resolve to empty array
     expect(scheduleMock).toHaveBeenCalledTimes(1); //schedule called once
+  });
+
+  test('fetchSearchItems returns raw items', async () => { //test helper directly
+    mock.onGet(/raw/).reply(200, { items: [{ title: 'r', snippet: 's', link: 'l' }] }); //mock response
+    const items = await fetchSearchItems('raw'); //call helper
+    expect(items).toEqual([{ title: 'r', snippet: 's', link: 'l' }]); //expect raw array
+    expect(scheduleMock).toHaveBeenCalled(); //schedule used
   });
 
   test('getTopSearchResults returns top links', async () => { //verify top links returned

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -73,6 +73,21 @@ function handleAxiosError(error, contextMsg) { //central axios error handler
         return res; //return result
 }
 
+async function fetchSearchItems(query) { //new shared fetcher for search items
+        console.log(`fetchSearchItems is running with ${query}`); //start log
+        try {
+                const url = getGoogleURL(query); //build request url
+                console.log(`Making request to: ${url}`); //log request
+                const response = await rateLimitedRequest(url); //perform request
+                const items = response.data.items || []; //parse items array
+                console.log(`fetchSearchItems returning ${items.length} items`); //end log
+                return items; //return items list
+        } catch (error) {
+                handleAxiosError(error, `Error in fetchSearchItems for query: ${query}`); //handle error
+                return []; //fallback empty array
+        }
+}
+
 /**
  * Get the top search result URL for each provided search term
  * @param {string[]} searchTerms - Array of search terms
@@ -93,24 +108,14 @@ async function getTopSearchResults(searchTerms) {
 	}
 	
 	console.log(`getTopSearchResults is running for search terms: ${validSearchTerms}`);
-	const searchResults = await Promise.all(validSearchTerms.map(async (query) => { // Use Promise.all() to wait for all promises returned by map() to resolve
-		const url = getGoogleURL(query);
-		console.log(`Making request to: ${url}`); // Log the request URL
-		try {
-			const response = await rateLimitedRequest(url);
-			const items = response.data.items;
-			if (items && items.length > 0) {
-				//console.log(`URL for "${query}": ${items[0].link}`);
-				return items[0].link; // Return the URL directly
-			} else {
-				console.log(`No results for "${query}"`);
-				return null; // Return null if no results
-			}
-                } catch (error) {
-                        handleAxiosError(error, `Error in getTopSearchResults for query: ${query}`); //replaced direct logging with helper
-                        return null; // Return null on error
+        const searchResults = await Promise.all(validSearchTerms.map(async (query) => { // Use Promise.all() to wait for all promises returned by map() to resolve
+                const items = await fetchSearchItems(query); //reuse fetchSearchItems
+                if (items.length > 0) { //check items length
+                        return items[0].link; //return first link
                 }
-	}));
+                console.log(`No results for "${query}"`); //log no results
+                return null; //return null when no items
+        }));
 	const validUrls = searchResults.filter(url => url !== null); // Filter out any null values if there were errors or no results
 	console.log(`Final URLs: ${validUrls}`);
 	return validUrls; // Return an array of strings (URLs)
@@ -129,14 +134,13 @@ async function googleSearch(query) {
 	}
 	
 	console.log(`googleSearch is running with query: ${query}`);
-	try {
-		const url = getGoogleURL(query);
-		const response = await rateLimitedRequest(url);
-		const results = response.data.items ? response.data.items.map(item => ({
-			title: item.title,
-			snippet: item.snippet,
-			link: item.link
-		})) : [];
+        try {
+                const items = await fetchSearchItems(query); //get search items
+                const results = items.map(item => ({ //map formatted results
+                        title: item.title,
+                        snippet: item.snippet,
+                        link: item.link
+                }));
 		console.log(`googleSearch returning ${results.length} results`);
 		return results;
         } catch (error) {
@@ -156,6 +160,7 @@ async function googleSearch(query) {
 module.exports = {
         googleSearch,
         getTopSearchResults,
+        fetchSearchItems, //added export for new helper
         rateLimitedRequest,
         getGoogleURL, //added export so tests can access this & returns search url
         handleAxiosError //added export so tests can access this & handle errors


### PR DESCRIPTION
## Summary
- extract shared `fetchSearchItems` helper from repeated code
- reuse helper in `googleSearch` and `getTopSearchResults`
- export helper for external use
- test helper directly in unit tests

## Testing
- `npm test` *(fails: jest not found)*