### PR TITLE
Refactor tests to share axios mock

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -1,34 +1,32 @@
 const axios = require('axios');
-const { setTestEnv, createScheduleMock, createQerrorsMock } = require('./utils/testSetup'); //import helpers
+const { setTestEnv, createScheduleMock, createQerrorsMock, createAxiosMock, resetMocks } = require('./utils/testSetup'); //import helpers
 
 setTestEnv(); //set up env vars
 const scheduleMock = createScheduleMock(); //mock Bottleneck
-
-jest.mock('axios'); //mock axios module
+let mock = createAxiosMock(); //create axios adapter
 
 const qerrorsMock = createQerrorsMock(); //mock qerrors
 
 beforeEach(() => {
-  jest.resetModules();
-  axios.get.mockClear();
-  scheduleMock.mockClear();
-  qerrorsMock.mockClear();
+  jest.resetModules(); //reset modules each test
+  mock = createAxiosMock(); //recreate axios adapter
+  resetMocks(mock, scheduleMock, qerrorsMock); //clear histories
 });
 
 test('rateLimitedRequest calls limiter and sets headers', async () => {
-  axios.get.mockResolvedValue({ data: {} });
+  mock.onGet('http://test').reply(200, {}); //mock axios success
   const { rateLimitedRequest } = require('../lib/qserp');
   await rateLimitedRequest('http://test');
   expect(scheduleMock).toHaveBeenCalled();
   expect(typeof scheduleMock.mock.calls[0][0]).toBe('function');
-  const config = axios.get.mock.calls[0][1];
-  expect(config.headers['User-Agent']).toMatch(/Mozilla/);
+  const config = mock.history.get[0].headers; //fetch request headers
+  expect(config['User-Agent']).toMatch(/Mozilla/);
 });
 
 test('rateLimitedRequest rejects on axios failure and schedules call', async () => {
-  axios.get.mockRejectedValue(new Error('net')); //mock axios failure & schedule check
+  mock.onGet('http://bad').networkError(); //simulate network error
   const { rateLimitedRequest } = require('../lib/qserp');
-  await expect(rateLimitedRequest('http://bad')).rejects.toThrow('net'); //promise rejects with error
+  await expect(rateLimitedRequest('http://bad')).rejects.toThrow('Network Error'); //axios rejects with error
   expect(scheduleMock).toHaveBeenCalled(); //ensure schedule invoked despite rejection
 });
 

--- a/__tests__/missingEnv.test.js
+++ b/__tests__/missingEnv.test.js
@@ -1,6 +1,7 @@
 
 let saveApi; //variable to store original api key
 let saveCx; //variable to store original cx
+let axiosMock; //adapter instance
 
 describe('throwIfMissingEnvVars', () => { //describe missing env block
   beforeAll(() => { //setup before tests
@@ -10,7 +11,8 @@ describe('throwIfMissingEnvVars', () => { //describe missing env block
     delete process.env.GOOGLE_CX; //clear cx
     process.env.OPENAI_TOKEN = 'token'; //set token for qerrors
     jest.resetModules(); //reset modules to apply env changes
-    jest.mock('axios'); //mock axios to avoid module error
+    const { createAxiosMock } = require('./utils/testSetup'); //import adapter
+    axiosMock = createAxiosMock(); //create axios adapter
   });
 
   afterAll(() => { //restore env vars


### PR DESCRIPTION
## Summary
- use `createAxiosMock()` utility in internal and env tests
- adapt header and error assertions to axios-mock-adapter

## Testing
- `npm test` *(fails: jest not found)*