### PR TITLE
Refactor tests with env helpers

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -1,19 +1,19 @@
-jest.mock('qerrors', () => jest.fn()); //switch to jest mock //(changed to clarify usage and current mocking)
-const qerrors = require('qerrors'); //get the mocked function //(added note that qerrors is mocked)
-
-const originalEnv = { ...process.env }; //capture starting environment //(store snapshot for reset)
+jest.mock('qerrors', () => jest.fn()); //switch to jest mock //(clarify usage)
+const qerrors = require('qerrors'); //get the mocked function //(qerrors mocked)
+const { saveEnv, restoreEnv } = require('./utils/testSetup'); //import env helpers //(new utilities)
 
 describe('envUtils', () => { //wrap all env util tests //(use describe as requested)
   let warnSpy; //declare warn spy //(track console warning)
 
+  let savedEnv; //holder for env snapshot //(for restoration)
   beforeEach(() => { //prepare each test //(reset env and mocks)
-    process.env = { ...originalEnv }; //reset environment between tests //(ensures isolation)
+    savedEnv = saveEnv(); //capture current env //(using util)
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {}); //mock console.warn //(avoid actual warnings)
     jest.resetModules(); //reload modules so env vars re-evaluated //(ensures clean require)
   });
 
   afterEach(() => { //cleanup after each test //(restore settings)
-    process.env = { ...originalEnv }; //restore environment after test //(reset env)
+    restoreEnv(savedEnv); //reset environment after test //(using util)
     warnSpy.mockRestore(); //restore console.warn //(remove spy)
     jest.clearAllMocks(); //clear any mock usage //(reset mock counts)
   });

--- a/__tests__/missingEnv.test.js
+++ b/__tests__/missingEnv.test.js
@@ -1,11 +1,9 @@
-
-let saveApi; //variable to store original api key
-let saveCx; //variable to store original cx
+const { saveEnv, restoreEnv } = require('./utils/testSetup'); //import env helpers //(new utilities)
+let savedEnv; //variable to store original env //(for restore)
 
 describe('throwIfMissingEnvVars', () => { //describe missing env block
   beforeAll(() => { //setup before tests
-    saveApi = process.env.GOOGLE_API_KEY; //save key
-    saveCx = process.env.GOOGLE_CX; //save cx
+    savedEnv = saveEnv(); //snapshot env //(using util)
     delete process.env.GOOGLE_API_KEY; //clear key
     delete process.env.GOOGLE_CX; //clear cx
     process.env.OPENAI_TOKEN = 'token'; //set token for qerrors
@@ -14,8 +12,7 @@ describe('throwIfMissingEnvVars', () => { //describe missing env block
   });
 
   afterAll(() => { //restore env vars
-    process.env.GOOGLE_API_KEY = saveApi; //restore key
-    process.env.GOOGLE_CX = saveCx; //restore cx
+    restoreEnv(savedEnv); //restore full env //(using util)
   });
 
   test('module throws when env vars missing', () => { //test thrown error on require

--- a/__tests__/utils/testSetup.js
+++ b/__tests__/utils/testSetup.js
@@ -7,6 +7,20 @@ function setTestEnv() {
   return true; //confirm env set
 }
 
+function saveEnv() { //(capture current process.env)
+  console.log(`saveEnv is running with none`); //initial log
+  const savedEnv = { ...process.env }; //copy environment vars
+  console.log(`saveEnv returning ${JSON.stringify(savedEnv)}`); //final log
+  return savedEnv; //return copy
+}
+
+function restoreEnv(savedEnv) { //(restore saved environment)
+  console.log(`restoreEnv is running with ${JSON.stringify(savedEnv)}`); //initial log
+  process.env = { ...savedEnv }; //restore env vars
+  console.log(`restoreEnv returning true`); //final log
+  return true; //confirm restore
+}
+
 function createScheduleMock() {
   console.log(`createScheduleMock is running with none`); //initial log
   const scheduleMock = jest.fn(fn => Promise.resolve(fn())); //mock schedule fn
@@ -51,5 +65,5 @@ function initSearchTest() { //helper to init env and mocks
   return { mock, scheduleMock, qerrorsMock }; //return configured mocks
 }
 
-module.exports = { setTestEnv, createScheduleMock, createQerrorsMock, createAxiosMock, resetMocks, initSearchTest }; //export helpers
+module.exports = { setTestEnv, saveEnv, restoreEnv, createScheduleMock, createQerrorsMock, createAxiosMock, resetMocks, initSearchTest }; //export helpers
 


### PR DESCRIPTION
## Summary
- extend testSetup with `saveEnv`/`restoreEnv`
- refactor `envUtils.test.js` to reuse new helpers
- refactor `missingEnv.test.js` to use new helpers

## Testing
- `npm test` *(fails: jest not found)*