### PR TITLE
Refactor search item retrieval

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -67,3 +67,20 @@ test('handleAxiosError returns false when qerrors throws', () => { //verify fall
   expect(spy).toHaveBeenCalled(); //console.error should log error message
   spy.mockRestore(); //restore console.error
 }); //end test ensuring failure path
+
+test('fetchSearchItems returns array of items on success', async () => { //verify helper success
+  axios.get.mockResolvedValue({ data: { items: ['a'] } }); //mock axios response
+  const { fetchSearchItems } = require('../lib/qserp'); //import helper under test
+  const items = await fetchSearchItems('ok'); //call helper
+  expect(items).toEqual(['a']); //expect returned items
+  expect(scheduleMock).toHaveBeenCalled(); //ensure rate limiter used
+});
+
+test('fetchSearchItems returns empty array and logs on failure', async () => { //verify helper failure
+  axios.get.mockRejectedValue(new Error('net')); //mock axios error
+  const { fetchSearchItems } = require('../lib/qserp'); //import helper
+  const items = await fetchSearchItems('bad'); //invoke failing helper
+  expect(items).toEqual([]); //should return empty array
+  expect(scheduleMock).toHaveBeenCalled(); //rate limiter should still run
+  expect(qerrorsMock).toHaveBeenCalled(); //error should be logged
+});

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -73,6 +73,20 @@ function handleAxiosError(error, contextMsg) { //central axios error handler
         return res; //return result
 }
 
+async function fetchSearchItems(query) { //pull raw items from google
+        console.log(`fetchSearchItems is running with query: ${query}`); //start log
+        try { //run request
+                const url = getGoogleURL(query); //build request url
+                const response = await rateLimitedRequest(url); //perform limited request
+                const items = response.data.items || []; //normalize items array
+                console.log(`fetchSearchItems returning ${items.length} items`); //final log
+                return items; //return raw items
+        } catch (error) { //handle error
+                handleAxiosError(error, `Error in fetchSearchItems for query: ${query}`); //delegated error handling
+                return []; //fallback to empty array
+        }
+}
+
 /**
  * Get the top search result URL for each provided search term
  * @param {string[]} searchTerms - Array of search terms
@@ -93,24 +107,14 @@ async function getTopSearchResults(searchTerms) {
 	}
 	
 	console.log(`getTopSearchResults is running for search terms: ${validSearchTerms}`);
-	const searchResults = await Promise.all(validSearchTerms.map(async (query) => { // Use Promise.all() to wait for all promises returned by map() to resolve
-		const url = getGoogleURL(query);
-		console.log(`Making request to: ${url}`); // Log the request URL
-		try {
-			const response = await rateLimitedRequest(url);
-			const items = response.data.items;
-			if (items && items.length > 0) {
-				//console.log(`URL for "${query}": ${items[0].link}`);
-				return items[0].link; // Return the URL directly
-			} else {
-				console.log(`No results for "${query}"`);
-				return null; // Return null if no results
-			}
-                } catch (error) {
-                        handleAxiosError(error, `Error in getTopSearchResults for query: ${query}`); //replaced direct logging with helper
-                        return null; // Return null on error
+        const searchResults = await Promise.all(validSearchTerms.map(async (query) => {
+                const items = await fetchSearchItems(query); //pull items via helper
+                if (items.length > 0) { //return first link when available
+                        return items[0].link;
                 }
-	}));
+                console.log(`No results for "${query}"`); //log no results
+                return null; //fallback when empty
+        }));
 	const validUrls = searchResults.filter(url => url !== null); // Filter out any null values if there were errors or no results
 	console.log(`Final URLs: ${validUrls}`);
 	return validUrls; // Return an array of strings (URLs)
@@ -128,17 +132,16 @@ async function googleSearch(query) {
 		throw new Error('Query must be a non-empty string');
 	}
 	
-	console.log(`googleSearch is running with query: ${query}`);
-	try {
-		const url = getGoogleURL(query);
-		const response = await rateLimitedRequest(url);
-		const results = response.data.items ? response.data.items.map(item => ({
-			title: item.title,
-			snippet: item.snippet,
-			link: item.link
-		})) : [];
-		console.log(`googleSearch returning ${results.length} results`);
-		return results;
+        console.log(`googleSearch is running with query: ${query}`);
+        try {
+                const items = await fetchSearchItems(query); //reuse helper for request
+                const results = items.map(item => ({ //format returned items
+                        title: item.title,
+                        snippet: item.snippet,
+                        link: item.link
+                }));
+                console.log(`googleSearch returning ${results.length} results`); //log result count
+                return results; //return formatted results
         } catch (error) {
                 handleAxiosError(error, `Error in googleSearch for query: ${query}`); //replaced direct logging with helper
                 return []; //error fallback
@@ -158,5 +161,6 @@ module.exports = {
         getTopSearchResults,
         rateLimitedRequest,
         getGoogleURL, //added export so tests can access this & returns search url
-        handleAxiosError //added export so tests can access this & handle errors
+        handleAxiosError, //added export so tests can access this & handle errors
+        fetchSearchItems //added export so tests can access this new helper
 };


### PR DESCRIPTION
## Summary
- add `fetchSearchItems` helper for shared search fetch logic
- reuse new helper in `googleSearch` and `getTopSearchResults`
- export helper and add unit tests

## Testing
- `npm test` *(fails: jest not found)*