### PR TITLE
Expose constant for OPENAI warning

### DIFF
--- a/__tests__/integrationCombined.test.js
+++ b/__tests__/integrationCombined.test.js
@@ -3,6 +3,7 @@ const { initSearchTest, resetMocks } = require('./utils/testSetup'); //use new h
 const { mock, scheduleMock, qerrorsMock } = initSearchTest(); //init environment and mocks
 
 const { googleSearch, getTopSearchResults } = require('../lib/qserp'); //load functions under test
+const { OPENAI_WARN_MSG } = require('../lib/constants'); //import warn constant
 
 describe('integration googleSearch and getTopSearchResults', () => { //describe block
   beforeEach(() => { //reset mocks
@@ -41,7 +42,7 @@ describe('integration googleSearch and getTopSearchResults', () => { //describe 
     mock.onGet(/Warn/).reply(200, { items: [{ title: 't', snippet: 's', link: 'l' }] }); //mock search success
     const res = await tokenlessSearch('Warn'); //perform search with mocked data
     expect(res).toEqual([{ title: 't', snippet: 's', link: 'l' }]); //ensure results returned
-    expect(warnSpy).toHaveBeenCalledWith('OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.'); //check warning message
+    expect(warnSpy).toHaveBeenCalledWith(OPENAI_WARN_MSG); //check warning message via constant
     warnSpy.mockRestore(); //restore console.warn
     process.env.OPENAI_TOKEN = saveToken; //restore original token
   });

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,5 +1,6 @@
 const REQUIRED_VARS = ['GOOGLE_API_KEY', 'GOOGLE_CX']; //define required env vars
 const OPTIONAL_VARS = ['OPENAI_TOKEN']; //define optional env vars
+const OPENAI_WARN_MSG = `OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.`; //new constant for warn text
 
-module.exports = { REQUIRED_VARS, OPTIONAL_VARS }; //export variables
+module.exports = { REQUIRED_VARS, OPTIONAL_VARS, OPENAI_WARN_MSG }; //export variables including warn message
 

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -7,7 +7,7 @@ const cx = process.env.GOOGLE_CX; // existing variable
 const qerrors = require('qerrors');
 const { safeRun } = require('./utils'); //import shared safeRun utility
 const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('./envUtils'); // import env utils
-const { REQUIRED_VARS, OPTIONAL_VARS } = require('./constants'); //import env constants
+const { REQUIRED_VARS, OPTIONAL_VARS, OPENAI_WARN_MSG } = require('./constants'); //import env constants and warn text
 
 
 // ADDED: Create a Bottleneck limiter with desired constraints:
@@ -44,7 +44,7 @@ const rateLimitedRequest = async (url) => {
 
 // Validate required environment variables using util
 throwIfMissingEnvVars(REQUIRED_VARS); //ensure API key and CX exist
-warnIfMissingEnvVars(OPTIONAL_VARS, 'OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.'); //warn if optional token missing
+warnIfMissingEnvVars(OPTIONAL_VARS, OPENAI_WARN_MSG); //warn if optional token missing using constant
 
 
 /**


### PR DESCRIPTION
## Summary
- add `OPENAI_WARN_MSG` constant
- use new constant in `qserp` logic
- update integration tests to use constant

## Testing
- `npm test` *(fails: jest not found)*