### PR TITLE
Refactor tests to use shared Axios mock

### DIFF
--- a/__tests__/missingEnv.test.js
+++ b/__tests__/missingEnv.test.js
@@ -1,6 +1,8 @@
 
+const { createAxiosMock } = require('./utils/testSetup'); //shared axios mock util
 let saveApi; //variable to store original api key
 let saveCx; //variable to store original cx
+let mock; //axios mock adapter instance
 
 describe('throwIfMissingEnvVars', () => { //describe missing env block
   beforeAll(() => { //setup before tests
@@ -10,12 +12,13 @@ describe('throwIfMissingEnvVars', () => { //describe missing env block
     delete process.env.GOOGLE_CX; //clear cx
     process.env.OPENAI_TOKEN = 'token'; //set token for qerrors
     jest.resetModules(); //reset modules to apply env changes
-    jest.mock('axios'); //mock axios to avoid module error
+    mock = createAxiosMock(); //init axios mock
   });
 
   afterAll(() => { //restore env vars
     process.env.GOOGLE_API_KEY = saveApi; //restore key
     process.env.GOOGLE_CX = saveCx; //restore cx
+    mock.reset(); //clear axios mock
   });
 
   test('module throws when env vars missing', () => { //test thrown error on require


### PR DESCRIPTION
## Summary
- refactor internalFunctions and missingEnv tests to use `createAxiosMock`
- clean up redundant axios mocking
- adapt assertions for axios-mock-adapter behavior

## Testing
- `npm test` *(fails: jest not found)*