### PR TITLE
Add env helpers for tests

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -1,19 +1,20 @@
+const { saveEnv, restoreEnv } = require('./utils/testSetup'); //import env helpers //(refactored for reuse)
 jest.mock('qerrors', () => jest.fn()); //switch to jest mock //(changed to clarify usage and current mocking)
 const qerrors = require('qerrors'); //get the mocked function //(added note that qerrors is mocked)
 
-const originalEnv = { ...process.env }; //capture starting environment //(store snapshot for reset)
+let envCopy; //var to hold env snapshot //(prepare restore)
 
 describe('envUtils', () => { //wrap all env util tests //(use describe as requested)
   let warnSpy; //declare warn spy //(track console warning)
 
   beforeEach(() => { //prepare each test //(reset env and mocks)
-    process.env = { ...originalEnv }; //reset environment between tests //(ensures isolation)
+    envCopy = saveEnv(); //capture env for restore //(use helper)
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {}); //mock console.warn //(avoid actual warnings)
     jest.resetModules(); //reload modules so env vars re-evaluated //(ensures clean require)
   });
 
   afterEach(() => { //cleanup after each test //(restore settings)
-    process.env = { ...originalEnv }; //restore environment after test //(reset env)
+    restoreEnv(envCopy); //restore environment after test //(use helper)
     warnSpy.mockRestore(); //restore console.warn //(remove spy)
     jest.clearAllMocks(); //clear any mock usage //(reset mock counts)
   });

--- a/__tests__/missingEnv.test.js
+++ b/__tests__/missingEnv.test.js
@@ -1,11 +1,10 @@
+const { saveEnv, restoreEnv } = require('./utils/testSetup'); //import env helpers //(refactored shared env logic)
 
-let saveApi; //variable to store original api key
-let saveCx; //variable to store original cx
+let envCopy; //variable to store env snapshot
 
 describe('throwIfMissingEnvVars', () => { //describe missing env block
   beforeAll(() => { //setup before tests
-    saveApi = process.env.GOOGLE_API_KEY; //save key
-    saveCx = process.env.GOOGLE_CX; //save cx
+    envCopy = saveEnv(); //snapshot env for restore //(use helper)
     delete process.env.GOOGLE_API_KEY; //clear key
     delete process.env.GOOGLE_CX; //clear cx
     process.env.OPENAI_TOKEN = 'token'; //set token for qerrors
@@ -14,8 +13,7 @@ describe('throwIfMissingEnvVars', () => { //describe missing env block
   });
 
   afterAll(() => { //restore env vars
-    process.env.GOOGLE_API_KEY = saveApi; //restore key
-    process.env.GOOGLE_CX = saveCx; //restore cx
+    restoreEnv(envCopy); //return env to original //(use helper)
   });
 
   test('module throws when env vars missing', () => { //test thrown error on require

--- a/__tests__/utils/testSetup.js
+++ b/__tests__/utils/testSetup.js
@@ -7,6 +7,20 @@ function setTestEnv() {
   return true; //confirm env set
 }
 
+function saveEnv() {
+  console.log(`saveEnv is running with none`); //initial log
+  const envCopy = { ...process.env }; //create env snapshot
+  console.log(`saveEnv returning copy`); //final log
+  return envCopy; //export snapshot
+}
+
+function restoreEnv(savedEnv) {
+  console.log(`restoreEnv is running with ${savedEnv}`); //initial log
+  process.env = { ...savedEnv }; //restore env from copy
+  console.log(`restoreEnv returning true`); //final log
+  return true; //confirm restore
+}
+
 function createScheduleMock() {
   console.log(`createScheduleMock is running with none`); //initial log
   const scheduleMock = jest.fn(fn => Promise.resolve(fn())); //mock schedule fn
@@ -51,5 +65,5 @@ function initSearchTest() { //helper to init env and mocks
   return { mock, scheduleMock, qerrorsMock }; //return configured mocks
 }
 
-module.exports = { setTestEnv, createScheduleMock, createQerrorsMock, createAxiosMock, resetMocks, initSearchTest }; //export helpers
+module.exports = { setTestEnv, saveEnv, restoreEnv, createScheduleMock, createQerrorsMock, createAxiosMock, resetMocks, initSearchTest }; //export helpers
 


### PR DESCRIPTION
## Summary
- create `saveEnv` and `restoreEnv` helpers
- use helpers in `envUtils` and `missingEnv` tests

## Testing
- `npm test` *(fails: jest not found)*