### PR TITLE
Add console spies helper for tests

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -1,6 +1,7 @@
 jest.mock('qerrors', () => jest.fn()); //switch to jest mock //(clarify usage)
 const qerrors = require('qerrors'); //get the mocked function //(qerrors mocked)
 const { saveEnv, restoreEnv } = require('./utils/testSetup'); //import env helpers //(new utilities)
+const { mockConsole } = require('./utils/consoleSpies'); //added console spy helper
 
 describe('envUtils', () => { //wrap all env util tests //(use describe as requested)
   let warnSpy; //declare warn spy //(track console warning)
@@ -8,7 +9,7 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
   let savedEnv; //holder for env snapshot //(for restoration)
   beforeEach(() => { //prepare each test //(reset env and mocks)
     savedEnv = saveEnv(); //capture current env //(using util)
-    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {}); //mock console.warn //(avoid actual warnings)
+    warnSpy = mockConsole('warn'); //mock console.warn via helper
     jest.resetModules(); //reload modules so env vars re-evaluated //(ensures clean require)
   });
 

--- a/__tests__/integrationCombined.test.js
+++ b/__tests__/integrationCombined.test.js
@@ -1,4 +1,5 @@
 const { initSearchTest, resetMocks } = require('./utils/testSetup'); //use new helpers
+const { mockConsole } = require('./utils/consoleSpies'); //added console spy helper
 
 const { mock, scheduleMock, qerrorsMock } = initSearchTest(); //init environment and mocks
 
@@ -37,7 +38,7 @@ describe('integration googleSearch and getTopSearchResults', () => { //describe 
     const saveToken = process.env.OPENAI_TOKEN; //store original token
     delete process.env.OPENAI_TOKEN; //remove token to trigger warning
     jest.resetModules(); //reset modules to reread env vars
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {}); //spy on console.warn
+    const warnSpy = mockConsole('warn'); //spy on console.warn using helper
     const { googleSearch: tokenlessSearch } = require('../lib/qserp'); //require module without token
     mock.onGet(/Warn/).reply(200, { items: [{ title: 't', snippet: 's', link: 'l' }] }); //mock search success
     const res = await tokenlessSearch('Warn'); //perform search with mocked data

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -1,5 +1,6 @@
 const axios = require('axios');
 const { setTestEnv, createScheduleMock, createQerrorsMock, createAxiosMock, resetMocks } = require('./utils/testSetup'); //import helpers
+const { mockConsole } = require('./utils/consoleSpies'); //added console spy helper
 
 setTestEnv(); //set up env vars
 const scheduleMock = createScheduleMock(); //mock Bottleneck
@@ -55,7 +56,7 @@ test('handleAxiosError logs with qerrors and returns true', () => {
 test('handleAxiosError logs response object and returns true', () => { //added new test for console.error
   const { handleAxiosError } = require('../lib/qserp'); //require function under test
   const err = { response: { status: 500 } }; //mock error with response
-  const spy = jest.spyOn(console, 'error').mockImplementation(() => {}); //spy on console.error
+  const spy = mockConsole('error'); //spy on console.error via helper
   const res = handleAxiosError(err, 'ctx'); //call function with response error
   expect(res).toBe(true); //should return true
   expect(spy).toHaveBeenCalledWith(err.response); //console.error called with response
@@ -67,7 +68,7 @@ test('handleAxiosError returns false when qerrors throws', () => { //verify fall
   const err = new Error('bad'); //mock basic error
   qerrorsMock.mockImplementationOnce(() => { throw new Error('qe'); }); //first call throws
   qerrorsMock.mockImplementation(() => {}); //subsequent calls succeed
-  const spy = jest.spyOn(console, 'error').mockImplementation(() => {}); //spy on console.error
+  const spy = mockConsole('error'); //spy on console.error via helper
   const res = handleAxiosError(err, 'ctx'); //invoke handler expecting false
   expect(res).toBe(false); //should return false due to catch block
   expect(spy).toHaveBeenCalled(); //console.error should log error message

--- a/__tests__/utils/consoleSpies.js
+++ b/__tests__/utils/consoleSpies.js
@@ -1,0 +1,8 @@
+function mockConsole(method) {
+  console.log(`mockConsole is running with ${method}`); //log start & method
+  const spy = jest.spyOn(console, method).mockImplementation(() => {}); //create spy with blank impl
+  console.log(`mockConsole returning spy`); //log returning spy
+  return spy; //return jest spy
+}
+
+module.exports = { mockConsole }; //export helper


### PR DESCRIPTION
## Summary
- provide `mockConsole` utility for jest console spies
- use `mockConsole` in env utils, integration tests, and internal function tests

## Testing
- `npm test` *(fails: jest not found)*