### PR TITLE
Refactor logging via logUtils

### DIFF
--- a/__tests__/utils/testSetup.js
+++ b/__tests__/utils/testSetup.js
@@ -1,67 +1,69 @@
+const { logStart, logReturn } = require('../../lib/logUtils'); //import log helpers
+
 function setTestEnv() {
-  console.log(`setTestEnv is running with default values`); //initial log
+  logStart('setTestEnv', 'default values'); //initial log via util
   process.env.GOOGLE_API_KEY = 'key'; //set common api key
   process.env.GOOGLE_CX = 'cx'; //set common cx id
   process.env.OPENAI_TOKEN = 'token'; //set common openai token
-  console.log(`setTestEnv returning true`); //final log
+  logReturn('setTestEnv', true); //final log via util
   return true; //confirm env set
 }
 
 function saveEnv() { //(capture current process.env)
-  console.log(`saveEnv is running with none`); //initial log
+  logStart('saveEnv', 'none'); //initial log via util
   const savedEnv = { ...process.env }; //copy environment vars
-  console.log(`saveEnv returning ${JSON.stringify(savedEnv)}`); //final log
+  logReturn('saveEnv', JSON.stringify(savedEnv)); //final log via util
   return savedEnv; //return copy
 }
 
 function restoreEnv(savedEnv) { //(restore saved environment)
-  console.log(`restoreEnv is running with ${JSON.stringify(savedEnv)}`); //initial log
+  logStart('restoreEnv', JSON.stringify(savedEnv)); //initial log via util
   process.env = { ...savedEnv }; //restore env vars
-  console.log(`restoreEnv returning true`); //final log
+  logReturn('restoreEnv', true); //final log via util
   return true; //confirm restore
 }
 
 function createScheduleMock() {
-  console.log(`createScheduleMock is running with none`); //initial log
+  logStart('createScheduleMock', 'none'); //initial log via util
   const scheduleMock = jest.fn(fn => Promise.resolve(fn())); //mock schedule fn
   jest.mock('bottleneck', () => jest.fn().mockImplementation(() => ({ schedule: scheduleMock }))); //mock bottleneck
-  console.log(`createScheduleMock returning mock`); //final log
+  logReturn('createScheduleMock', 'mock'); //final log via util
   return scheduleMock; //export schedule mock
 }
 
 function createQerrorsMock() {
-  console.log(`createQerrorsMock is running with none`); //initial log
+  logStart('createQerrorsMock', 'none'); //initial log via util
   const qerrorsMock = jest.fn(); //mock qerrors fn
   jest.mock('qerrors', () => (...args) => qerrorsMock(...args)); //mock qerrors
-  console.log(`createQerrorsMock returning mock`); //final log
+  logReturn('createQerrorsMock', 'mock'); //final log via util
   return qerrorsMock; //export qerrors mock
 }
 
 function createAxiosMock() {
-  console.log(`createAxiosMock is running with none`); //initial log
+  logStart('createAxiosMock', 'none'); //initial log via util
   const MockAdapter = require('axios-mock-adapter'); //import mock adapter
   const axios = require('axios'); //import axios instance
   const mock = new MockAdapter(axios); //create adapter instance
-  console.log(`createAxiosMock returning adapter`); //final log
+  logReturn('createAxiosMock', 'adapter'); //final log via util
   return mock; //export axios mock
 }
 
 function resetMocks(mock, scheduleMock, qerrorsMock) { //helper to clear mocks
-  console.log(`resetMocks is running with mocks`); //initial log
+  logStart('resetMocks', 'mocks'); //initial log via util
   mock.reset(); //clear axios mock history
   scheduleMock.mockClear(); //clear Bottleneck schedule calls
   qerrorsMock.mockClear(); //clear qerrors call history
-  console.log(`resetMocks returning true`); //final log
+  logReturn('resetMocks', true); //final log via util
   return true; //confirm reset
 }
 
 function initSearchTest() { //helper to init env and mocks
-  console.log(`initSearchTest is running with none`); //initial log
+  logStart('initSearchTest', 'none'); //initial log via util
   setTestEnv(); //prepare environment variables
   const scheduleMock = createScheduleMock(); //create schedule mock
   const qerrorsMock = createQerrorsMock(); //create qerrors mock
   const mock = createAxiosMock(); //create axios mock
-  console.log(`initSearchTest returning mocks`); //final log
+  logReturn('initSearchTest', 'mocks'); //final log via util
   return { mock, scheduleMock, qerrorsMock }; //return configured mocks
 }
 

--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -1,9 +1,10 @@
 const { safeRun } = require('./utils'); //import shared safeRun utility
+const { logStart, logReturn } = require('./logUtils'); //import log helpers
 
 function safeEnvCall(fnName, fn, defaultVal, context) { //(wrap env calls safely)
-        console.log(`safeEnvCall is running with ${fnName}`); //(initial log for wrapper)
+        logStart('safeEnvCall', fnName); //(initial log via util)
         const res = safeRun(fnName, fn, defaultVal, context); //(use shared utility)
-        console.log(`safeEnvCall returning ${res}`); //(log final result)
+        logReturn('safeEnvCall', res); //(log final result via util)
         return res; //(return result from safeRun)
 }
 

--- a/lib/logUtils.js
+++ b/lib/logUtils.js
@@ -1,0 +1,9 @@
+function logStart(fnName, details) { //helper to standardize start logs
+        console.log(`${fnName} is running with ${details}`); //log start message
+}
+
+function logReturn(fnName, result) { //helper to standardize return logs
+        console.log(`${fnName} returning ${result}`); //log return message
+}
+
+module.exports = { logStart, logReturn }; //export helpers at bottom

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -6,6 +6,7 @@ const cx = process.env.GOOGLE_CX; // existing variable
 // It requires an OPENAI_TOKEN environment variable to work properly
 const qerrors = require('qerrors');
 const { safeRun } = require('./utils'); //import shared safeRun utility
+const { logStart, logReturn } = require('./logUtils'); //import log helpers
 const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('./envUtils'); // import env utils
 const { REQUIRED_VARS, OPTIONAL_VARS, OPENAI_WARN_MSG } = require('./constants'); //import env constants and warning msg
 
@@ -59,7 +60,7 @@ function getGoogleURL(query) {
 }
 
 function handleAxiosError(error, contextMsg) { //central axios error handler
-        console.log(`handleAxiosError is running with ${contextMsg}`); //start log
+        logStart('handleAxiosError', contextMsg); //start log via util
         const res = safeRun('handleAxiosError', () => { //use safeRun wrapper
                 if (error.response) { //check for response
                         console.error(error.response); //log response object
@@ -69,18 +70,18 @@ function handleAxiosError(error, contextMsg) { //central axios error handler
                 qerrors(error, contextMsg, {contextMsg}); //central error handling
                 return true; //confirm handled
         }, false, {contextMsg});
-        console.log(`handleAxiosError returning ${res}`); //final log
+        logReturn('handleAxiosError', res); //final log via util
         return res; //return result
 }
 
 async function fetchSearchItems(query) { //new shared fetcher for search items
-        console.log(`fetchSearchItems is running with ${query}`); //start log
+        logStart('fetchSearchItems', query); //start log via util
         try {
                 const url = getGoogleURL(query); //build request url
                 console.log(`Making request to: ${url}`); //log request
                 const response = await rateLimitedRequest(url); //perform request
                 const items = response.data.items || []; //parse items array
-                console.log(`fetchSearchItems returning ${items.length} items`); //end log
+                logReturn('fetchSearchItems', `${items.length} items`); //end log via util
                 return items; //return items list
         } catch (error) {
                 handleAxiosError(error, `Error in fetchSearchItems for query: ${query}`); //handle error
@@ -107,7 +108,7 @@ async function getTopSearchResults(searchTerms) {
 		return [];
 	}
 	
-	console.log(`getTopSearchResults is running for search terms: ${validSearchTerms}`);
+        logStart('getTopSearchResults', validSearchTerms); //start log via util
         const searchResults = await Promise.all(validSearchTerms.map(async (query) => { // Use Promise.all() to wait for all promises returned by map() to resolve
                 const items = await fetchSearchItems(query); //reuse fetchSearchItems
                 if (items.length > 0) { //check items length
@@ -117,7 +118,7 @@ async function getTopSearchResults(searchTerms) {
                 return null; //return null when no items
         }));
 	const validUrls = searchResults.filter(url => url !== null); // Filter out any null values if there were errors or no results
-	console.log(`Final URLs: ${validUrls}`);
+        logReturn('getTopSearchResults', validUrls); //final log via util
 	return validUrls; // Return an array of strings (URLs)
 }
 
@@ -133,7 +134,7 @@ async function googleSearch(query) {
 		throw new Error('Query must be a non-empty string');
 	}
 	
-	console.log(`googleSearch is running with query: ${query}`);
+        logStart('googleSearch', query); //log start via util
         try {
                 const items = await fetchSearchItems(query); //get search items
                 const results = items.map(item => ({ //map formatted results
@@ -141,7 +142,7 @@ async function googleSearch(query) {
                         snippet: item.snippet,
                         link: item.link
                 }));
-		console.log(`googleSearch returning ${results.length} results`);
+                logReturn('googleSearch', `${results.length} results`); //log return via util
 		return results;
         } catch (error) {
                 handleAxiosError(error, `Error in googleSearch for query: ${query}`); //replaced direct logging with helper

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,14 +1,15 @@
 const qerrors = require('qerrors'); //import qerrors for error handling
+const { logStart, logReturn } = require('./logUtils'); //import log helpers
 
 function safeRun(fnName, fn, defaultVal, context) { //add shared safe executor
-        console.log(`safeRun is running with ${JSON.stringify({fnName, context})}`); //log input
+        logStart('safeRun', JSON.stringify({ fnName, context })); //log input via util
         try { //begin try
                 const result = fn(); //execute callback
-                console.log(`safeRun returning ${result}`); //log result
+                logReturn('safeRun', result); //log result via util
                 return result; //return successful result
         } catch (error) { //catch errors
                 qerrors(error, `${fnName} error`, context); //report with qerrors
-                console.log(`safeRun returning ${defaultVal}`); //log fallback
+                logReturn('safeRun', defaultVal); //log fallback via util
                 return defaultVal; //return fallback value
         }
 }


### PR DESCRIPTION
## Summary
- add reusable logStart/logReturn helpers
- refactor utils, envUtils, qserp, and tests to use the new logging

## Testing
- `npm test` *(fails: jest not found)*