### PR TITLE
Add OPENAI_WARN_MSG constant

### DIFF
--- a/__tests__/constants.test.js
+++ b/__tests__/constants.test.js
@@ -1,6 +1,7 @@
-const { REQUIRED_VARS, OPTIONAL_VARS } = require('../lib/constants'); //import constants to test their values
+const { REQUIRED_VARS, OPTIONAL_VARS, OPENAI_WARN_MSG } = require('../lib/constants'); //import constants to test their values
 
 test('constants arrays have expected entries', () => { //verify exports
   expect(REQUIRED_VARS).toEqual(['GOOGLE_API_KEY', 'GOOGLE_CX']); //should match required list
   expect(OPTIONAL_VARS).toEqual(['OPENAI_TOKEN']); //should match optional list
+  expect(OPENAI_WARN_MSG).toBe('OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.'); //should match warning text
 });

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -52,6 +52,13 @@ const REQUIRED_VARS = ['GOOGLE_API_KEY', 'GOOGLE_CX'];
 const OPTIONAL_VARS = ['OPENAI_TOKEN'];
 
 /**
+ * Warning message when OPENAI_TOKEN is missing
+ *
+ * Centralized string so tests and runtime use the same value
+ */
+const OPENAI_WARN_MSG = 'OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.'; //(added constant)
+
+/**
  * Module exports
  * 
  * These constants are exported for use by environment validation functions
@@ -62,6 +69,7 @@ const OPTIONAL_VARS = ['OPENAI_TOKEN'];
  * the criticality level and expected handling for each group.
  */
 module.exports = {
-	REQUIRED_VARS,  // Critical variables that must be present
-	OPTIONAL_VARS   // Enhancing variables that improve functionality but aren't essential
+        REQUIRED_VARS,  // Critical variables that must be present
+        OPTIONAL_VARS,  // Enhancing variables that improve functionality but aren't essential
+        OPENAI_WARN_MSG // Warning text when optional token missing
 };

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -19,7 +19,7 @@ const qerrors = require('qerrors');
 // Import utility functions for environment variable validation
 // These utilities centralize env var handling to avoid repetitive validation code
 const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('./envUtils');
-const { REQUIRED_VARS, OPTIONAL_VARS } = require('./constants'); // Centralized env var definitions
+const { REQUIRED_VARS, OPTIONAL_VARS, OPENAI_WARN_MSG } = require('./constants'); // Centralized env var definitions with warning message
 
 /**
  * Rate limiter configuration using Bottleneck
@@ -78,7 +78,7 @@ throwIfMissingEnvVars(REQUIRED_VARS); // Will throw Error if API key or CX missi
 
 // Warn about optional environment variables that enhance functionality
 // OPENAI_TOKEN is used by qerrors for enhanced error analysis but isn't strictly required
-warnIfMissingEnvVars(OPTIONAL_VARS, 'OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.');
+warnIfMissingEnvVars(OPTIONAL_VARS, OPENAI_WARN_MSG); //use centralized warning text
 
 /**
  * Generates a Google Custom Search API URL with proper encoding


### PR DESCRIPTION
## Summary
- centralize OpenAI warning message in `lib/constants.js`
- use `OPENAI_WARN_MSG` inside `lib/qserp.js`
- export the constant and test for it

## Testing
- `npm test` *(fails: jest not found)*