### PR TITLE
Add fetchSearchItems helper

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -140,8 +140,32 @@ function handleAxiosError(error, contextMsg) {
 }
 
 /**
+ * Fetch raw Google search items for a query
+ *
+ * This helper abstracts the repetitive request/response handling when
+ * only the raw items array from Google is needed by other functions.
+ *
+ * @param {string} query - Search term to look up
+ * @returns {Promise<Array>} Raw items array from Google or empty array on error
+ */
+async function fetchSearchItems(query) {
+        console.log(`fetchSearchItems is running with ${query}`); //(start log of function execution)
+        try {
+                const url = getGoogleURL(query); //(build search url)
+                const response = await rateLimitedRequest(url); //(perform rate limited axios request)
+                const items = response.data.items || []; //(extract items array if present)
+                console.log(`fetchSearchItems returning ${JSON.stringify(items)}`); //(log return value)
+                return items; //(return extracted items array)
+        } catch (error) {
+                handleAxiosError(error, `Error in fetchSearchItems for query: ${query}`); //(handle and log any axios errors)
+                console.log(`fetchSearchItems returning []`); //(log empty array due to failure)
+                return []; //(gracefully return empty array)
+        }
+}
+
+/**
  * Get the top search result URL for each provided search term
- * 
+ *
  * This function performs parallel searches for multiple terms and returns only the
  * top result URL for each. It's designed for use cases where you need quick access
  * to the most relevant result for each query without processing full result sets.
@@ -265,12 +289,13 @@ async function googleSearch(query) {
  * exported for testing but should not be used directly by consumers.
  */
 module.exports = {
-	// Primary public API functions
-	googleSearch,           // Single search with detailed results
-	getTopSearchResults,    // Multiple searches returning top URLs only
-	
-	// Internal functions exported for testing
-	rateLimitedRequest,     // HTTP request wrapper with rate limiting
-	getGoogleURL,           // URL builder for Google API
-	handleAxiosError        // Centralized error handler
+        // Primary public API functions
+        googleSearch,           // Single search with detailed results
+        getTopSearchResults,    // Multiple searches returning top URLs only
+        fetchSearchItems,       // Raw search helper returning Google items
+
+        // Internal functions exported for testing
+        rateLimitedRequest,     // HTTP request wrapper with rate limiting
+        getGoogleURL,           // URL builder for Google API
+        handleAxiosError        // Centralized error handler
 };


### PR DESCRIPTION
## Summary
- add `fetchSearchItems` to simplify retrieving raw search items
- export new helper from library

## Testing
- `npm test` *(fails: jest not found)*