### PR TITLE
Fix warnIfMissingEnvVars return type

### DIFF
--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -98,7 +98,7 @@ function throwIfMissingEnvVars(varArr) {
  * 
  * @param {string[]} varArr - Array of optional environment variable names to check
  * @param {string} customMessage - Custom warning message to display (optional)
- * @returns {string[]} Array of missing variable names for potential use by caller
+ * @returns {boolean} True if all variables are present, otherwise false
  */
 function warnIfMissingEnvVars(varArr, customMessage = '') {
 	console.log(`warnIfMissingEnvVars is running with ${varArr}`); // Debug log for tracing execution
@@ -119,16 +119,17 @@ function warnIfMissingEnvVars(varArr, customMessage = '') {
 			console.warn(warningMessage);
 		}
 		
-		console.log(`warnIfMissingEnvVars returning ${missingEnvVars}`); // Log results for debugging
-		return missingEnvVars; // Return missing variables so caller can take action if needed
+                const result = missingEnvVars.length === 0; //determine if any vars missing //(compute boolean)
+                console.log(`warnIfMissingEnvVars returning ${result}`); // Log boolean result for debugging
+                return result; //inform caller if all vars present //(boolean instead of array)
 		
 	} catch (error) {
 		// Error handling for unexpected failures
 		// Even if warning fails, we shouldn't halt execution for optional variables
 		qerrors(error, 'warnIfMissingEnvVars error', {varArr, customMessage});
-		console.log(`warnIfMissingEnvVars returning []`); // Safe fallback on error
-		return []; // Return empty array to indicate no missing variables detected
-	}
+                console.log(`warnIfMissingEnvVars returning false`); // Safe fallback on error
+                return false; //Return false on error to indicate failure //(boolean result)
+        }
 }
 
 /**


### PR DESCRIPTION
## Summary
- return boolean from `warnIfMissingEnvVars`
- update docs to reflect new return type

## Testing
- `npm test` *(fails: jest not found)*