### PR TITLE
Implement CODEX mock path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ npm test
 These tests mock network requests and set the necessary environment variables
 internally, so no API credentials are required.
 
+## Running on Codex
+
+When the environment variable `CODEX` is set to `True`, the library avoids
+network requests and instead returns a mocked response from search functions.
+This behavior enables local execution inside Codex where outbound internet
+access is disabled.
+
+Example:
+
+```javascript
+process.env.CODEX = 'True';
+const { googleSearch } = require('qserp');
+googleSearch('test').then(res => console.log(res)); // returns []
+```
+
 ## License
 
 ISC

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -56,20 +56,31 @@ const limiter = new Bottleneck({
  * @throws {Error} - Network errors, timeouts, or HTTP error status codes
  * @private - Internal function not exposed in module exports
  */
-const rateLimitedRequest = async (url) => {
-	// Use limiter.schedule to automatically handle rate limiting
-	// This returns a promise that resolves when the request is allowed to proceed
-	return limiter.schedule(() =>
-		axios.get(url, {
-			timeout: 10000, // 10 second timeout to prevent hanging requests
-			headers: {
-				// User-Agent header mimics Chrome browser to avoid bot detection
-				// Some APIs may block requests with missing or obvious bot user agents
-				'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36'
-			}
-		})
-	);
-};
+async function rateLimitedRequest(url) { //(handle network request with optional mock)
+        console.log(`rateLimitedRequest is running with ${url}`); //(function entry log)
+
+        if (process.env.CODEX === 'True') { //(check if running on codex)
+                const mockRes = { data: { items: [] } }; //(define mock axios-like response)
+                console.log('rateLimitedRequest using codex mock response'); //(notify mock path taken)
+                console.log(`rateLimitedRequest returning ${JSON.stringify(mockRes)}`); //(mock return log)
+                return mockRes; //(return mocked response)
+        }
+
+        // Use limiter.schedule to automatically handle rate limiting
+        // This returns a promise that resolves when the request is allowed to proceed
+        const res = await limiter.schedule(() =>
+                axios.get(url, {
+                        timeout: 10000, // 10 second timeout to prevent hanging requests
+                        headers: {
+                                // User-Agent header mimics Chrome browser to avoid bot detection
+                                // Some APIs may block requests with missing or obvious bot user agents
+                                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36'
+                        }
+                })
+        );
+        console.log(`rateLimitedRequest returning ${JSON.stringify(res.data)}`); //(log real response)
+        return res; //(return axios response)
+}
 
 // Validate required environment variables at module load time
 // This ensures the module fails fast if critical configuration is missing


### PR DESCRIPTION
## Summary
- mock API calls in `rateLimitedRequest` when running on Codex
- log when mock data is used
- document Codex behaviour in README

## Testing
- `npm test` *(fails: jest not found)*