### PR TITLE
Fix env utils tests and error handling

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -35,7 +35,7 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     process.env.A = '1'; //define env A only //(setup)
     delete process.env.B; //remove env B //(force missing)
     expect(getMissingEnvVars(['A', 'B'])).toEqual(['B']); //should detect B missing //(assert)
-    expect(throwIfMissingEnvVars(['A', 'B'])).toEqual([]); //error path handled //(assert)
+    expect(() => throwIfMissingEnvVars(['A', 'B'])).toThrow('Missing required'); //should throw on missing vars //(assert)
     expect(warnIfMissingEnvVars(['A', 'B'], 'warn')).toBe(false); //should warn //(assert)
     expect(warnSpy).toHaveBeenCalledWith('warn'); //warn called with message //(check)
     expect(qerrors).toHaveBeenCalledTimes(1); //qerrors invoked once //(check)

--- a/__tests__/utils/testSetup.js
+++ b/__tests__/utils/testSetup.js
@@ -18,7 +18,8 @@ function saveEnv() { //(capture current process.env)
 
 function restoreEnv(savedEnv) { //(restore saved environment)
   logStart('restoreEnv', JSON.stringify(savedEnv)); //initial log via util
-  process.env = { ...savedEnv }; //restore env vars
+  Object.keys(process.env).forEach(k => delete process.env[k]); //clear current env //(avoid reassignment)
+  Object.assign(process.env, savedEnv); //copy saved vars back //(restore vars)
   logReturn('restoreEnv', true); //final log via util
   return true; //confirm restore
 }

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -18,7 +18,7 @@ const qerrors = require('qerrors');
 
 // Import utility functions for environment variable validation
 // These utilities centralize env var handling to avoid repetitive validation code
-const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('./envUtils');
+const { throwIfMissingEnvVars, warnIfMissingEnvVars } = require('./envUtils'); //env validation utilities //(trim unused)
 const { REQUIRED_VARS, OPTIONAL_VARS, OPENAI_WARN_MSG } = require('./constants'); // Centralized env var definitions with warning message
 
 /**
@@ -142,12 +142,13 @@ function handleAxiosError(error, contextMsg) {
 		console.log(`handleAxiosError returning true`); // Confirm successful error handling
 		return true; // Indicate error was handled successfully
 	} catch (err) {
-		// Error occurred within the error handler itself
-		// This is a critical failure that needs separate logging
-		qerrors(err, 'handleAxiosError error', {contextMsg});
-		console.log(`handleAxiosError returning false`); // Indicate handler failure
-		return false; // Indicate error handling failed
-	}
+                // Error occurred within the error handler itself
+                // Attempt logging the secondary error and keep flow stable
+                try { qerrors(err, 'handleAxiosError error', {contextMsg}); } //log secondary error //(attempt qerrors)
+                catch (qe) { console.error(qe); } //fallback logging //(prevent crash)
+                console.log(`handleAxiosError returning false`); // Indicate handler failure
+                return false; // Indicate error handling failed
+        }
 }
 
 /**


### PR DESCRIPTION
## Summary
- fix test to expect throw from throwIfMissingEnvVars
- ensure restoreEnv copies env variables safely
- catch qerrors failure inside handleAxiosError
- remove unused import

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a4099902c8322a4de3d4641ae4773