### PR TITLE
Use adapter in internal test

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -32,7 +32,7 @@ test('rateLimitedRequest rejects on axios failure and schedules call', async () 
 });
 
 test('fetchSearchItems returns items and schedules call', async () => { //new helper test
-  axios.get.mockResolvedValue({ data: { items: [{ link: 'x' }] } }); //mock success
+  mock.onGet(/term/).reply(200, { items: [{ link: 'x' }] }); //mock success using adapter
   const { fetchSearchItems } = require('../lib/qserp'); //load helper
   const items = await fetchSearchItems('term'); //invoke helper
   expect(items).toEqual([{ link: 'x' }]); //check items array


### PR DESCRIPTION
## Summary
- replace mockResolvedValue with adapter-based mocking in internalFunctions.test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bc2417d848322abeff57401c16d97