### PR TITLE
Validate query for fetchSearchItems

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -42,6 +42,7 @@ describe('qserp module', () => { //group qserp tests
 
   test('handles empty or invalid input', async () => { //verify validation paths
     await expect(googleSearch('')).rejects.toThrow(); //expect empty query throw
+    await expect(fetchSearchItems('')).rejects.toThrow(); //expect empty query throw for helper
     await expect(getTopSearchResults('bad')).rejects.toThrow(); //expect invalid input throw
     const emptyUrls = await getTopSearchResults([]); //call with empty list
     expect(emptyUrls).toEqual([]); //expect empty array result

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -162,6 +162,7 @@ function handleAxiosError(error, contextMsg) {
  */
 async function fetchSearchItems(query) {
         console.log(`fetchSearchItems is running with ${query}`); //(start log of function execution)
+        if (typeof query !== 'string' || query.trim() === '') { throw new Error(`Query must be a non-empty string`); } //(verify query is valid)
         try {
                 const url = getGoogleURL(query); //(build search url)
                 const response = await rateLimitedRequest(url); //(perform rate limited axios request)


### PR DESCRIPTION
## Summary
- validate `query` arg in `fetchSearchItems`
- test that `fetchSearchItems` rejects empty input

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bcd6f4bb08322b42c478adf3ab69f