### PR TITLE
Improve CODEX flag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Before using the module, set the following environment variables. `OPENAI_TOKEN`
 - `GOOGLE_API_KEY` – Your Google API key. You can obtain this from the [Google Cloud Console](https://console.cloud.google.com/).
 - `GOOGLE_CX` – Your Custom Search Engine ID. Set this up at [Google Programmable Search Engine](https://programmablesearchengine.google.com/).
 - `OPENAI_TOKEN` – Optional. Used by the `qerrors` dependency for enhanced logging.
-- `CODEX` – When set to `True`, network calls are mocked so the module can run without internet access.
+- `CODEX` – When set to any case-insensitive `true` value, network calls are mocked so the module can run without internet access.
 
 
 
@@ -43,7 +43,7 @@ internally, so no API credentials are required.
 
 ## Running on Codex
 
-When the environment variable `CODEX` is set to `True`, the library avoids
+When the environment variable `CODEX` is set to any case-insensitive `true` value, the library avoids
 network requests and instead returns a mocked response from search functions.
 This behavior enables local execution inside Codex where outbound internet
 access is disabled.
@@ -51,7 +51,7 @@ access is disabled.
 Example:
 
 ```javascript
-process.env.CODEX = 'True';
+process.env.CODEX = 'true';
 const { googleSearch } = require('qserp');
 googleSearch('test').then(res => console.log(res)); // returns []
 ```

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -74,3 +74,13 @@ test('handleAxiosError returns false when qerrors throws', () => { //verify fall
   expect(spy).toHaveBeenCalled(); //console.error should log error message
   spy.mockRestore(); //restore console.error
 }); //end test ensuring failure path
+
+test.each(['True', 'true', 'TRUE', true])('rateLimitedRequest returns mock when CODEX=%s', async val => {
+  process.env.CODEX = val; //set CODEX variant to trigger mock response
+  const { rateLimitedRequest } = require('../lib/qserp'); //import after setting env
+  const res = await rateLimitedRequest('http://codex'); //call function expecting mock
+  expect(res).toEqual({ data: { items: [] } }); //mocked empty items returned
+  expect(scheduleMock).not.toHaveBeenCalled(); //limiter should be bypassed
+  expect(mock.history.get.length).toBe(0); //axios should not receive any request
+  delete process.env.CODEX; //clean up env variable for other tests
+}); //test ensures CODEX casings bypass network

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -59,7 +59,7 @@ const limiter = new Bottleneck({
 async function rateLimitedRequest(url) { //(handle network request with optional mock)
         console.log(`rateLimitedRequest is running with ${url}`); //(function entry log)
 
-        if (process.env.CODEX === 'True') { //(check if running on codex)
+        if (String(process.env.CODEX).toLowerCase() === 'true') { //(use case-insensitive true check for codex mock)
                 const mockRes = { data: { items: [] } }; //(define mock axios-like response)
                 console.log('rateLimitedRequest using codex mock response'); //(notify mock path taken)
                 console.log(`rateLimitedRequest returning ${JSON.stringify(mockRes)}`); //(mock return log)


### PR DESCRIPTION
## Summary
- detect `CODEX` env var ignoring case in `rateLimitedRequest`
- clarify README about any case-insensitive `true` enabling mocks
- test CODEX behavior with various casings

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bcd6fedbc8322aa921b6818b34a34