### PR TITLE
Fix jest mocks and env handling

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -1,5 +1,5 @@
 jest.mock('qerrors', () => jest.fn()); //switch to jest mock //(clarify usage)
-const qerrors = require('qerrors'); //get the mocked function //(qerrors mocked)
+let qerrors; //will hold mocked function after module reset
 const { saveEnv, restoreEnv } = require('./utils/testSetup'); //import env helpers //(new utilities)
 const { mockConsole } = require('./utils/consoleSpies'); //added console spy helper
 
@@ -11,6 +11,7 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     savedEnv = saveEnv(); //capture current env //(using util)
     warnSpy = mockConsole('warn'); //mock console.warn via helper
     jest.resetModules(); //reload modules so env vars re-evaluated //(ensures clean require)
+    qerrors = require('qerrors'); //re-acquire mock after module reset
   });
 
   afterEach(() => { //cleanup after each test //(restore settings)

--- a/__tests__/indexExport.test.js
+++ b/__tests__/indexExport.test.js
@@ -1,3 +1,5 @@
+process.env.GOOGLE_API_KEY = 'key'; //set required api key for module load
+process.env.GOOGLE_CX = 'cx'; //set required cx id for module load
 const indexExports = require('../index'); //(import index module to test re-export)
 const libExports = require('../lib/qserp'); //(import direct lib module)
 

--- a/__tests__/integrationCombined.test.js
+++ b/__tests__/integrationCombined.test.js
@@ -1,7 +1,7 @@
-const { initSearchTest, resetMocks } = require('./utils/testSetup'); //use new helpers
+const { initSearchTest, resetMocks, createScheduleMock, createQerrorsMock, createAxiosMock } = require('./utils/testSetup'); //use helpers
 const { mockConsole } = require('./utils/consoleSpies'); //added console spy helper
 
-const { mock, scheduleMock, qerrorsMock } = initSearchTest(); //init environment and mocks
+let { mock, scheduleMock, qerrorsMock } = initSearchTest(); //init environment and mocks
 
 const { googleSearch, getTopSearchResults } = require('../lib/qserp'); //load functions under test
 const { OPENAI_WARN_MSG } = require('../lib/constants'); //import warning constant
@@ -38,6 +38,9 @@ describe('integration googleSearch and getTopSearchResults', () => { //describe 
     const saveToken = process.env.OPENAI_TOKEN; //store original token
     delete process.env.OPENAI_TOKEN; //remove token to trigger warning
     jest.resetModules(); //reset modules to reread env vars
+    mock = createAxiosMock(); //recreate axios adapter for new module instance
+    createScheduleMock(); //recreate bottleneck mock after reset
+    createQerrorsMock(); //recreate qerrors mock after reset
     const warnSpy = mockConsole('warn'); //spy on console.warn using helper
     const { googleSearch: tokenlessSearch } = require('../lib/qserp'); //require module without token
     mock.onGet(/Warn/).reply(200, { items: [{ title: 't', snippet: 's', link: 'l' }] }); //mock search success

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -3,14 +3,16 @@ const { setTestEnv, createScheduleMock, createQerrorsMock, createAxiosMock, rese
 const { mockConsole } = require('./utils/consoleSpies'); //added console spy helper
 
 setTestEnv(); //set up env vars
-const scheduleMock = createScheduleMock(); //mock Bottleneck
+let scheduleMock = createScheduleMock(); //mock Bottleneck
 let mock = createAxiosMock(); //create axios adapter
 
-const qerrorsMock = createQerrorsMock(); //mock qerrors
+let qerrorsMock = createQerrorsMock(); //mock qerrors
 
 beforeEach(() => {
   jest.resetModules(); //reset modules each test
   mock = createAxiosMock(); //recreate axios adapter
+  scheduleMock = createScheduleMock(); //reapply bottleneck mock after module reset
+  qerrorsMock = createQerrorsMock(); //reapply qerrors mock after module reset
   resetMocks(mock, scheduleMock, qerrorsMock); //clear histories
 });
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   testEnvironment: 'node', //set node environment for tests
+  testMatch: ['**/*.test.js'], //only treat files with .test.js suffix as tests
 };

--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -10,7 +10,9 @@
  * This approach improves developer experience and reduces troubleshooting time.
  */
 
-const qerrors = require('qerrors'); // Import qerrors for structured error logging
+// Import qerrors and normalize export to a callable function
+const qerrMod = require('qerrors');
+const qerrors = typeof qerrMod === 'function' ? qerrMod : qerrMod.qerrors || qerrMod.default; //support multiple export styles
 
 /**
  * Identifies which environment variables from a given list are missing

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -13,8 +13,9 @@ const apiKey = process.env.GOOGLE_API_KEY; // Google API key from environment - 
 const cx = process.env.GOOGLE_CX; // Custom Search Engine ID from environment - defines search scope
 
 // qerrors is used to handle error reporting and logging with structured context
-// It requires an OPENAI_TOKEN environment variable to work properly for AI-enhanced error analysis
-const qerrors = require('qerrors');
+// Library export shape may vary, so normalize to function for compatibility
+const qerrModule = require('qerrors');
+const qerrors = typeof qerrModule === 'function' ? qerrModule : qerrModule.qerrors || qerrModule.default; //resolve function export
 
 // Import utility functions for environment variable validation
 // These utilities centralize env var handling to avoid repetitive validation code


### PR DESCRIPTION
## Summary
- normalize `qerrors` import to handle different module shapes
- mock utilities without cross-scope variables
- ensure tests set required env vars and refresh mocks after `jest.resetModules`
- run only `*.test.js` files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683fac3ff73483229c13e316c9622cc3