### PR TITLE
Fix API key leak in logging

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -58,7 +58,8 @@ const limiter = new Bottleneck({
  * @private - Internal function not exposed in module exports
  */
 async function rateLimitedRequest(url) { //(handle network request with optional mock)
-        console.log(`rateLimitedRequest is running with ${url}`); //(function entry log)
+        const safeUrl = url.replace(apiKey, '[redacted]'); //(sanitize api key from url)
+        console.log(`rateLimitedRequest is running with ${safeUrl}`); //(avoid key leak)
 
         if (String(process.env.CODEX).toLowerCase() === 'true') { //(use case-insensitive true check for codex mock)
                 const mockRes = { data: { items: [] } }; //(define mock axios-like response)


### PR DESCRIPTION
## Summary
- sanitize URL logging in `rateLimitedRequest`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68435acfd99c8322abcd84527ff7c555