### PR TITLE
Centralize qerrors loader

### DIFF
--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -10,9 +10,8 @@
  * This approach improves developer experience and reduces troubleshooting time.
  */
 
-// Import qerrors and normalize export to a callable function
-const qerrMod = require('qerrors');
-const qerrors = typeof qerrMod === 'function' ? qerrMod : qerrMod.qerrors || qerrMod.default; //support multiple export styles
+// Import qerrors using shared loader
+const qerrors = require('./qerrorsLoader')(); //retrieve qerrors function via loader
 
 /**
  * Identifies which environment variables from a given list are missing

--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -1,0 +1,23 @@
+/**
+ * qerrorsLoader.js - Utility to obtain the qerrors function regardless of export style
+ *
+ * This loader normalizes the export shape of the qerrors dependency, which may
+ * be exported as a default or named property. It returns the callable function
+ * so that importing modules don't repeat this logic.
+ */
+
+function loadQerrors() {
+        console.log(`loadQerrors is running with ${JSON.stringify(Object.keys(require('qerrors')))}?`); //debug module keys
+        try {
+                const mod = require('qerrors'); //import qerrors module
+                const qerrors = typeof mod === 'function' ? mod : mod.qerrors || mod.default; //resolve exported function
+                console.log(`loadQerrors returning ${qerrors.name}`); //log selected function name
+                return qerrors; //return callable qerrors function
+        } catch (error) {
+                console.error(error); //log loader failure
+                throw error; //re-throw loader error
+        }
+}
+
+module.exports = loadQerrors; //export loader
+

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -13,9 +13,7 @@ const apiKey = process.env.GOOGLE_API_KEY; // Google API key from environment - 
 const cx = process.env.GOOGLE_CX; // Custom Search Engine ID from environment - defines search scope
 
 // qerrors is used to handle error reporting and logging with structured context
-// Library export shape may vary, so normalize to function for compatibility
-const qerrModule = require('qerrors');
-const qerrors = typeof qerrModule === 'function' ? qerrModule : qerrModule.qerrors || qerrModule.default; //resolve function export
+const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
 
 // Import utility functions for environment variable validation
 // These utilities centralize env var handling to avoid repetitive validation code


### PR DESCRIPTION
## Summary
- add qerrorsLoader utility to normalize qerrors exports
- use loader in qserp and envUtils to reduce duplication

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68436195150c832295c7a52d5540fd3b