### PR TITLE
Add query validation helper and refactor searches

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -154,6 +154,25 @@ function handleAxiosError(error, contextMsg) {
 }
 
 /**
+ * Validate that a search query is a non-empty string
+ *
+ * This helper centralizes input validation for search functions so that
+ * both fetchSearchItems and googleSearch enforce the same requirements.
+ *
+ * @param {any} query - Value to validate as search term
+ * @throws {Error} If query is not a non-empty string
+ */
+function validateSearchQuery(query) {
+        console.log(`validateSearchQuery is running with ${query}`); //(start log of validation)
+        if (typeof query !== 'string' || query.trim() === '') { //(check for non-empty string)
+                console.log('validateSearchQuery throwing Query must be a non-empty string'); //(log failure)
+                throw new Error('Query must be a non-empty string'); //(throw on invalid input)
+        }
+        console.log('validateSearchQuery returning true'); //(log successful validation)
+        return true; //(confirm valid query)
+}
+
+/**
  * Fetch raw Google search items for a query
  *
  * This helper abstracts the repetitive request/response handling when
@@ -164,7 +183,7 @@ function handleAxiosError(error, contextMsg) {
  */
 async function fetchSearchItems(query) {
         console.log(`fetchSearchItems is running with ${query}`); //(start log of function execution)
-        if (typeof query !== 'string' || query.trim() === '') { throw new Error(`Query must be a non-empty string`); } //(verify query is valid)
+        validateSearchQuery(query); //(reuse validation helper)
         try {
                 const url = getGoogleURL(query); //(build search url)
                 const response = await rateLimitedRequest(url); //(perform rate limited axios request)
@@ -214,31 +233,14 @@ async function getTopSearchResults(searchTerms) {
 	// Use Promise.all() to execute all searches in parallel
 	// This is much faster than sequential execution, especially with rate limiting
 	// Each search is independent, so parallel execution is safe and beneficial
-	const searchResults = await Promise.all(validSearchTerms.map(async (query) => {
-		const url = getGoogleURL(query);
-		console.log(`Making request to: ${url}`); // Debug log for request tracking
-		
-		try {
-			const response = await rateLimitedRequest(url);
-			const items = response.data.items; // Google API returns results in 'items' array
-			
-			if (items && items.length > 0) {
-				// Return the URL of the first (top) result
-				// Google orders results by relevance, so first result is most relevant
-				return items[0].link;
-			} else {
-				// No results found for this query
-				// This can happen with very specific or misspelled queries
-				console.log(`No results for "${query}"`);
-				return null; // Use null to indicate no result (will be filtered out)
-			}
-		} catch (error) {
-			// Use centralized error handling for consistency
-			// Continue processing other queries even if one fails
-			handleAxiosError(error, `Error in getTopSearchResults for query: ${query}`);
-			return null; // Return null on error so other results can still be processed
-		}
-	}));
+        const searchResults = await Promise.all(validSearchTerms.map(async (query) => {
+                const items = await fetchSearchItems(query); //(reuse helper for request)
+                if (items.length > 0) { //(check for available results)
+                        return items[0].link; //(return first result link)
+                }
+                console.log(`No results for "${query}"`); //(log when query yields nothing)
+                return null; //(indicate absence of result)
+        }));
 	
 	// Filter out null values (failed searches or no results)
 	// This ensures the returned array contains only valid URLs
@@ -262,33 +264,16 @@ async function getTopSearchResults(searchTerms) {
  * @throws {Error} If query is not a string or is empty
  */
 async function googleSearch(query) {
-	// Input validation: ensure query is a non-empty string
-	// Empty queries would waste API quota and return meaningless results
-	if (typeof query !== 'string' || query.trim() === '') {
-		throw new Error('Query must be a non-empty string');
-	}
-	
-	console.log(`googleSearch is running with query: ${query}`);
-	
-	try {
-		const url = getGoogleURL(query);
-		const response = await rateLimitedRequest(url);
-		
-		// Transform Google API response into simplified, consistent format
-		// Extract only the fields most commonly needed by applications
-		const results = response.data.items ? response.data.items.map(item => ({
-			title: item.title,     // Page title
-			snippet: item.snippet, // Brief description/excerpt
-			link: item.link        // URL to the page
-		})) : []; // Return empty array if no results rather than undefined
-		
-		console.log(`googleSearch returning ${results.length} results`);
-		return results;
-	} catch (error) {
-		// Use centralized error handling for consistency
-		handleAxiosError(error, `Error in googleSearch for query: ${query}`);
-		return []; // Return empty array on error for graceful degradation
-	}
+        validateSearchQuery(query); //(ensure non-empty string input)
+        console.log(`googleSearch is running with query: ${query}`);
+        const items = await fetchSearchItems(query); //(perform search via helper)
+        const results = items.map(item => ({ //(map items to simplified objects)
+                title: item.title,
+                snippet: item.snippet,
+                link: item.link
+        }));
+        console.log(`googleSearch returning ${results.length} results`);
+        return results;
 }
 
 /**


### PR DESCRIPTION
## Summary
- centralize validation with new `validateSearchQuery`
- reuse `fetchSearchItems` in `googleSearch` and `getTopSearchResults`
- update related function calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843618f2ce883229fd4c816cbe3e18b