### PR TITLE
Use logUtils in loader and test spies

### DIFF
--- a/__tests__/utils/consoleSpies.js
+++ b/__tests__/utils/consoleSpies.js
@@ -1,7 +1,9 @@
+const { logStart, logReturn } = require('../../lib/logUtils'); //import logging utilities
+
 function mockConsole(method) {
-  console.log(`mockConsole is running with ${method}`); //log start & method
+  logStart('mockConsole', method); //log start & method
   const spy = jest.spyOn(console, method).mockImplementation(() => {}); //create spy with blank impl
-  console.log(`mockConsole returning spy`); //log returning spy
+  logReturn('mockConsole', 'spy'); //log returning spy
   return spy; //return jest spy
 }
 

--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -6,12 +6,14 @@
  * so that importing modules don't repeat this logic.
  */
 
+const { logStart, logReturn } = require('./logUtils'); //import standardized logging utilities
+
 function loadQerrors() {
-        console.log(`loadQerrors is running with ${JSON.stringify(Object.keys(require('qerrors')))}?`); //debug module keys
+        logStart('loadQerrors', 'qerrors module'); //log start before require
         try {
                 const mod = require('qerrors'); //import qerrors module
                 const qerrors = typeof mod === 'function' ? mod : mod.qerrors || mod.default; //resolve exported function
-                console.log(`loadQerrors returning ${qerrors.name}`); //log selected function name
+                logReturn('loadQerrors', qerrors.name); //log selected function name
                 return qerrors; //return callable qerrors function
         } catch (error) {
                 console.error(error); //log loader failure


### PR DESCRIPTION
## Summary
- use `logStart`/`logReturn` helpers in `lib/qerrorsLoader.js`
- use the same helpers in test `consoleSpies`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684369ea40588322af4b90357d9b3145