### PR TITLE
Refactor logging to logUtils

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -14,6 +14,7 @@ const cx = process.env.GOOGLE_CX; // Custom Search Engine ID from environment - 
 
 // qerrors is used to handle error reporting and logging with structured context
 const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
+const { logStart, logReturn } = require('./logUtils'); //standardized logging utilities
 
 // Import utility functions for environment variable validation
 // These utilities centralize env var handling to avoid repetitive validation code
@@ -57,12 +58,12 @@ const limiter = new Bottleneck({
  */
 async function rateLimitedRequest(url) { //(handle network request with optional mock)
         const safeUrl = url.replace(apiKey, '[redacted]'); //(sanitize api key from url)
-        console.log(`rateLimitedRequest is running with ${safeUrl}`); //(avoid key leak)
+        logStart('rateLimitedRequest', safeUrl); //(avoid key leak)
 
         if (String(process.env.CODEX).toLowerCase() === 'true') { //(use case-insensitive true check for codex mock)
                 const mockRes = { data: { items: [] } }; //(define mock axios-like response)
                 console.log('rateLimitedRequest using codex mock response'); //(notify mock path taken)
-                console.log(`rateLimitedRequest returning ${JSON.stringify(mockRes)}`); //(mock return log)
+                logReturn('rateLimitedRequest', JSON.stringify(mockRes)); //(mock return log)
                 return mockRes; //(return mocked response)
         }
 
@@ -78,7 +79,7 @@ async function rateLimitedRequest(url) { //(handle network request with optional
                         }
                 })
         );
-        console.log(`rateLimitedRequest returning ${JSON.stringify(res.data)}`); //(log real response)
+        logReturn('rateLimitedRequest', JSON.stringify(res.data)); //(log real response)
         return res; //(return axios response)
 }
 
@@ -121,7 +122,7 @@ function getGoogleURL(query) {
  * @returns {boolean} - true if error was handled successfully, false if handler itself failed
  */
 function handleAxiosError(error, contextMsg) {
-	console.log(`handleAxiosError is running with ${contextMsg}`); // Debug log for error handling flow
+        logStart('handleAxiosError', contextMsg); //debug log for error handling flow
 	
 	try {
 		// Check if error has a response (HTTP error) vs no response (network error)
@@ -139,14 +140,14 @@ function handleAxiosError(error, contextMsg) {
 		// This enables better error tracking and analysis across the application
 		qerrors(error, contextMsg, {contextMsg});
 		
-		console.log(`handleAxiosError returning true`); // Confirm successful error handling
-		return true; // Indicate error was handled successfully
+                logReturn('handleAxiosError', true); // Confirm successful error handling
+                return true; // Indicate error was handled successfully
 	} catch (err) {
                 // Error occurred within the error handler itself
                 // Attempt logging the secondary error and keep flow stable
                 try { qerrors(err, 'handleAxiosError error', {contextMsg}); } //log secondary error //(attempt qerrors)
                 catch (qe) { console.error(qe); } //fallback logging //(prevent crash)
-                console.log(`handleAxiosError returning false`); // Indicate handler failure
+                logReturn('handleAxiosError', false); // Indicate handler failure
                 return false; // Indicate error handling failed
         }
 }
@@ -161,12 +162,12 @@ function handleAxiosError(error, contextMsg) {
  * @throws {Error} If query is not a non-empty string
  */
 function validateSearchQuery(query) {
-        console.log(`validateSearchQuery is running with ${query}`); //(start log of validation)
+        logStart('validateSearchQuery', query); //(start log of validation)
         if (typeof query !== 'string' || query.trim() === '') { //(check for non-empty string)
                 console.log('validateSearchQuery throwing Query must be a non-empty string'); //(log failure)
                 throw new Error('Query must be a non-empty string'); //(throw on invalid input)
         }
-        console.log('validateSearchQuery returning true'); //(log successful validation)
+        logReturn('validateSearchQuery', true); //(log successful validation)
         return true; //(confirm valid query)
 }
 
@@ -180,17 +181,17 @@ function validateSearchQuery(query) {
  * @returns {Promise<Array>} Raw items array from Google or empty array on error
  */
 async function fetchSearchItems(query) {
-        console.log(`fetchSearchItems is running with ${query}`); //(start log of function execution)
+        logStart('fetchSearchItems', query); //(start log of function execution)
         validateSearchQuery(query); //(reuse validation helper)
         try {
                 const url = getGoogleURL(query); //(build search url)
                 const response = await rateLimitedRequest(url); //(perform rate limited axios request)
                 const items = response.data.items || []; //(extract items array if present)
-                console.log(`fetchSearchItems returning ${JSON.stringify(items)}`); //(log return value)
+                logReturn('fetchSearchItems', JSON.stringify(items)); //(log return value)
                 return items; //(return extracted items array)
         } catch (error) {
                 handleAxiosError(error, `Error in fetchSearchItems for query: ${query}`); //(handle and log any axios errors)
-                console.log(`fetchSearchItems returning []`); //(log empty array due to failure)
+                logReturn('fetchSearchItems', '[]'); //(log empty array due to failure)
                 return []; //(gracefully return empty array)
         }
 }
@@ -226,7 +227,7 @@ async function getTopSearchResults(searchTerms) {
 		return []; // Return empty array rather than failing - graceful degradation
 	}
 	
-	console.log(`getTopSearchResults is running for search terms: ${validSearchTerms}`);
+        logStart('getTopSearchResults', validSearchTerms); //(log start with valid terms)
 	
 	// Use Promise.all() to execute all searches in parallel
 	// This is much faster than sequential execution, especially with rate limiting
@@ -242,9 +243,9 @@ async function getTopSearchResults(searchTerms) {
 	
 	// Filter out null values (failed searches or no results)
 	// This ensures the returned array contains only valid URLs
-	const validUrls = searchResults.filter(url => url !== null);
-	console.log(`Final URLs: ${validUrls}`);
-	return validUrls; // Return array of strings (URLs only)
+        const validUrls = searchResults.filter(url => url !== null);
+        logReturn('getTopSearchResults', validUrls); //(log return array of urls)
+        return validUrls; // Return array of strings (URLs only)
 }
 
 /**
@@ -263,14 +264,14 @@ async function getTopSearchResults(searchTerms) {
  */
 async function googleSearch(query) {
         validateSearchQuery(query); //(ensure non-empty string input)
-        console.log(`googleSearch is running with query: ${query}`);
+        logStart('googleSearch', query); //(start log of search)
         const items = await fetchSearchItems(query); //(perform search via helper)
         const results = items.map(item => ({ //(map items to simplified objects)
                 title: item.title,
                 snippet: item.snippet,
                 link: item.link
         }));
-        console.log(`googleSearch returning ${results.length} results`);
+        logReturn('googleSearch', results.length); //(log number of results)
         return results;
 }
 


### PR DESCRIPTION
## Summary
- import `logStart` and `logReturn`
- use `logUtils` in qserp helper functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684369e0896483228b74390d67082235