### PR TITLE
Use standard log utils in env utils

### DIFF
--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -12,6 +12,7 @@
 
 // Import qerrors using shared loader
 const qerrors = require('./qerrorsLoader')(); //retrieve qerrors function via loader
+const { logStart, logReturn } = require('./logUtils'); //import standardized log utilities
 
 /**
  * Identifies which environment variables from a given list are missing
@@ -24,7 +25,7 @@ const qerrors = require('./qerrorsLoader')(); //retrieve qerrors function via lo
  * @returns {string[]} Array of missing variable names (empty if all present)
  */
 function getMissingEnvVars(varArr) {
-	console.log(`getMissingEnvVars is running with ${varArr}`); // Debug log for tracing execution
+       logStart('getMissingEnvVars', varArr); //log start of function with provided vars
 	
 	try {
 		// Filter returns only variables that are undefined or empty
@@ -32,15 +33,15 @@ function getMissingEnvVars(varArr) {
 		// Both cases are treated as "missing" since empty env vars are rarely useful
 		const missingArr = varArr.filter(name => !process.env[name]);
 		
-		console.log(`getMissingEnvVars returning ${missingArr}`); // Log results for debugging
-		return missingArr;
+               logReturn('getMissingEnvVars', missingArr); //log function result
+               return missingArr;
 	} catch (error) {
 		// Error handling for unexpected failures (e.g., varArr not being an array)
 		// Use qerrors for structured logging with context about what was being checked
-		qerrors(error, 'getMissingEnvVars error', {varArr});
-		console.log(`getMissingEnvVars returning []`); // Safe fallback on error
-		return []; // Return empty array to prevent downstream errors
-	}
+               qerrors(error, 'getMissingEnvVars error', {varArr});
+               logReturn('getMissingEnvVars', []); //log fallback result on error
+               return []; // Return empty array to prevent downstream errors
+       }
 }
 
 /**
@@ -55,7 +56,7 @@ function getMissingEnvVars(varArr) {
  * @returns {string[]} Empty array if no variables are missing (for testing purposes)
  */
 function throwIfMissingEnvVars(varArr) {
-	console.log(`throwIfMissingEnvVars is running with ${varArr}`); // Debug log for tracing execution
+       logStart('throwIfMissingEnvVars', varArr); //log start of function with provided vars
 	
 	try {
 		// Get list of missing variables using our utility function
@@ -76,8 +77,8 @@ function throwIfMissingEnvVars(varArr) {
 			throw new Error(errorMessage);
 		}
 		
-		console.log(`throwIfMissingEnvVars has run resulting in a final value of ${missingEnvVars}`);
-		return missingEnvVars; // Return empty array when all variables are present (useful for testing)
+               logReturn('throwIfMissingEnvVars', missingEnvVars); //log function result
+               return missingEnvVars; // Return empty array when all variables are present (useful for testing)
 		
 	} catch (error) {
 		// Handle both our intentionally thrown errors and unexpected errors
@@ -102,7 +103,7 @@ function throwIfMissingEnvVars(varArr) {
  * @returns {boolean} True if all variables are present, otherwise false
  */
 function warnIfMissingEnvVars(varArr, customMessage = '') {
-	console.log(`warnIfMissingEnvVars is running with ${varArr}`); // Debug log for tracing execution
+       logStart('warnIfMissingEnvVars', varArr); //log start of function with provided vars
 	
 	try {
 		// Reuse our core missing variable detection logic
@@ -120,17 +121,17 @@ function warnIfMissingEnvVars(varArr, customMessage = '') {
 			console.warn(warningMessage);
 		}
 		
-                const result = missingEnvVars.length === 0; //determine if any vars missing //(compute boolean)
-                console.log(`warnIfMissingEnvVars returning ${result}`); // Log boolean result for debugging
-                return result; //inform caller if all vars present //(boolean instead of array)
+               const result = missingEnvVars.length === 0; //determine if any vars missing //(compute boolean)
+               logReturn('warnIfMissingEnvVars', result); //log function result
+               return result; //inform caller if all vars present //(boolean instead of array)
 		
 	} catch (error) {
 		// Error handling for unexpected failures
 		// Even if warning fails, we shouldn't halt execution for optional variables
-		qerrors(error, 'warnIfMissingEnvVars error', {varArr, customMessage});
-                console.log(`warnIfMissingEnvVars returning false`); // Safe fallback on error
-                return false; //Return false on error to indicate failure //(boolean result)
-        }
+               qerrors(error, 'warnIfMissingEnvVars error', {varArr, customMessage});
+               logReturn('warnIfMissingEnvVars', false); //log fallback result on error
+               return false; //Return false on error to indicate failure //(boolean result)
+       }
 }
 
 /**


### PR DESCRIPTION
## Summary
- centralize logging behavior in `envUtils`
- use `logStart` and `logReturn` instead of `console.log`

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_b_684369da3f888322bef76eb1684f7376