### PR TITLE
Remove duplicate qerrors mock

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -1,5 +1,4 @@
-jest.mock('qerrors', () => jest.fn()); //switch to jest mock //(clarify usage)
-let qerrors; //will hold mocked function after module reset
+let qerrors; //holds mock loaded after reset (setup in testSetup)
 const { saveEnv, restoreEnv } = require('./utils/testSetup'); //import env helpers //(new utilities)
 const { mockConsole } = require('./utils/consoleSpies'); //added console spy helper
 


### PR DESCRIPTION
## Summary
- remove redundant qerrors mock from env utils test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68436f7c92cc83229932cc0b62634a4b