### PR TITLE
Add tests for utils and loaders

### DIFF
--- a/__tests__/logUtils.test.js
+++ b/__tests__/logUtils.test.js
@@ -1,0 +1,19 @@
+const { mockConsole } = require('./utils/consoleSpies'); //import helper for spies
+
+const { logStart, logReturn } = require('../lib/logUtils'); //functions under test
+
+describe('log utils', () => { //group log utility tests
+  test('logStart outputs expected message', () => { //verify logStart format
+    const spy = mockConsole('log'); //spy on console.log
+    logStart('fn', 'details'); //invoke logStart
+    expect(spy).toHaveBeenCalledWith('fn is running with details'); //check message
+    spy.mockRestore(); //restore console.log
+  });
+
+  test('logReturn outputs expected message', () => { //verify logReturn format
+    const spy = mockConsole('log'); //spy on console.log
+    logReturn('fn', 'result'); //invoke logReturn
+    expect(spy).toHaveBeenCalledWith('fn returning result'); //check message
+    spy.mockRestore(); //restore console.log
+  });
+});

--- a/__tests__/qerrorsLoader.test.js
+++ b/__tests__/qerrorsLoader.test.js
@@ -1,0 +1,30 @@
+describe('loadQerrors', () => { //group loader tests
+  test('returns default exported function', () => { //test default export shape
+    jest.isolateModules(() => { //isolate module for mocking
+      jest.doMock('qerrors', () => jest.fn(() => 'def')); //mock module as function
+      const loadQerrors = require('../lib/qerrorsLoader'); //import loader after mock
+      const fn = loadQerrors(); //invoke loader
+      expect(fn()).toBe('def'); //returned function works
+    });
+  });
+
+  test('returns named qerrors export', () => { //test named property shape
+    jest.isolateModules(() => { //isolate module for mocking
+      const qf = jest.fn(() => 'named'); //mock function
+      jest.doMock('qerrors', () => ({ qerrors: qf })); //mock module object
+      const loadQerrors = require('../lib/qerrorsLoader'); //import loader
+      const fn = loadQerrors(); //invoke loader
+      expect(fn()).toBe('named'); //returned function works
+    });
+  });
+
+  test('returns default property export', () => { //test default property shape
+    jest.isolateModules(() => { //isolate module for mocking
+      const df = jest.fn(() => 'prop'); //mock function
+      jest.doMock('qerrors', () => ({ default: df })); //mock module object
+      const loadQerrors = require('../lib/qerrorsLoader'); //import loader
+      const fn = loadQerrors(); //invoke loader
+      expect(fn()).toBe('prop'); //returned function works
+    });
+  });
+});

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,23 @@
+const { createQerrorsMock } = require('./utils/testSetup'); //import qerrors mock helper
+
+const { safeRun } = require('../lib/utils'); //import function under test
+
+describe('safeRun', () => { //group safeRun tests
+  test('returns result when function succeeds', () => { //success branch
+    const qerrors = createQerrorsMock(); //reset qerrors mock
+    const fn = jest.fn(() => 5); //mock function returning value
+    const res = safeRun('testFn', fn, 0, { a: 1 }); //execute safeRun
+    expect(res).toBe(5); //should return fn result
+    expect(fn).toHaveBeenCalled(); //function called
+    expect(qerrors).not.toHaveBeenCalled(); //qerrors unused
+  });
+
+  test('returns default value and logs error when function throws', () => { //failure branch
+    const qerrors = createQerrorsMock(); //reset qerrors mock
+    const fn = jest.fn(() => { throw new Error('fail'); }); //mock throwing fn
+    const res = safeRun('badFn', fn, 1, { b: 2 }); //execute safeRun
+    expect(res).toBe(1); //should return fallback
+    expect(fn).toHaveBeenCalled(); //function called
+    expect(qerrors).toHaveBeenCalledWith(expect.any(Error), 'badFn error', { b: 2 }); //qerrors invoked
+  });
+});


### PR DESCRIPTION
## Summary
- cover `safeRun` success and failure paths
- test log utilities with console spies
- verify `loadQerrors` handles various export shapes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68439172d2f48322aa3ad00428e0a54b