### PR TITLE
Add validateSearchQuery export and tests

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -81,3 +81,13 @@ test.each(['True', 'true', 'TRUE', true])('rateLimitedRequest returns mock when 
   expect(mock.history.get.length).toBe(0); //axios should not receive any request
   delete process.env.CODEX; //clean up env variable for other tests
 }); //test ensures CODEX casings bypass network
+
+test('validateSearchQuery accepts non-empty strings', () => { //(verify valid input)
+  const { validateSearchQuery } = require('../lib/qserp'); //import helper
+  expect(validateSearchQuery('ok')).toBe(true); //should return true for normal string
+});
+
+test.each(['', '   ', 1, {}, []])('validateSearchQuery throws for %p', val => { //(verify invalid inputs)
+  const { validateSearchQuery } = require('../lib/qserp'); //import helper
+  expect(() => validateSearchQuery(val)).toThrow('Query must be a non-empty string'); //expect error thrown
+});

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -297,4 +297,5 @@ module.exports = {
         rateLimitedRequest,     // HTTP request wrapper with rate limiting
         getGoogleURL,           // URL builder for Google API
         handleAxiosError        // Centralized error handler
+       , validateSearchQuery    // Validation helper for query strings //(export validation function)
 };


### PR DESCRIPTION
## Summary
- export `validateSearchQuery` from `lib/qserp.js`
- test `validateSearchQuery` with valid and invalid inputs

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68439178f0a883229b2b63925c4841cd