### PR TITLE
Add warning test for getTopSearchResults

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -3,6 +3,7 @@ const { initSearchTest, resetMocks } = require('./utils/testSetup'); //use new h
 const { mock, scheduleMock, qerrorsMock } = initSearchTest(); //initialize env and mocks
 
 const { googleSearch, getTopSearchResults, fetchSearchItems } = require('../lib/qserp'); //load functions under test from library
+const { OPENAI_WARN_MSG } = require('../lib/constants'); //import warning message constant
 
 describe('qserp module', () => { //group qserp tests
   beforeEach(() => { //reset mocks before each test
@@ -64,5 +65,24 @@ describe('qserp module', () => { //group qserp tests
     const urls = await getTopSearchResults(terms); //execute search with mixed array
     expect(urls).toEqual(['http://b']); //should only include valid link
     expect(scheduleMock).toHaveBeenCalledTimes(2); //rate limiter for valid terms only
+  });
+
+  test('warns on missing OPENAI_TOKEN for getTopSearchResults', async () => { //new warning test
+    const tokenSave = process.env.OPENAI_TOKEN; //store existing token for restore
+    delete process.env.OPENAI_TOKEN; //remove token to trigger warning logic
+    jest.resetModules(); //reload modules to re-evaluate env vars
+    const { createAxiosMock, createScheduleMock, createQerrorsMock } = require('./utils/testSetup'); //reacquire helpers post reset
+    const warnSpy = require('./utils/consoleSpies').mockConsole('warn'); //create console.warn spy
+    const mockLocal = createAxiosMock(); //create fresh axios adapter
+    createScheduleMock(); //recreate Bottleneck schedule mock
+    createQerrorsMock(); //recreate qerrors mock
+    const { getTopSearchResults: topSearch } = require('../lib/qserp'); //require module without token
+    mockLocal.onGet(/One/).reply(200, { items: [{ link: '1' }] }); //mock first term
+    mockLocal.onGet(/Two/).reply(200, { items: [{ link: '2' }] }); //mock second term
+    const urls = await topSearch(['One', 'Two']); //run function expecting warning
+    expect(urls).toEqual(['1', '2']); //ensure urls returned correctly
+    expect(warnSpy).toHaveBeenCalledWith(OPENAI_WARN_MSG); //warning should reference constant
+    warnSpy.mockRestore(); //restore console.warn spy
+    process.env.OPENAI_TOKEN = tokenSave; //restore original token
   });
 });


### PR DESCRIPTION
## Summary
- import OPENAI_WARN_MSG constant in qserp tests
- ensure getTopSearchResults warns when OPENAI_TOKEN is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684391838bd883229e336e52f379cd27