### PR TITLE
Fix qerrors loader validation

### DIFF
--- a/__tests__/qerrorsLoader.test.js
+++ b/__tests__/qerrorsLoader.test.js
@@ -27,4 +27,12 @@ describe('loadQerrors', () => { //group loader tests
       expect(fn()).toBe('prop'); //returned function works
     });
   });
+
+  test('throws when export is not function', () => { //invalid export should throw
+    jest.isolateModules(() => { //isolate module for mocking
+      jest.doMock('qerrors', () => ({ qerrors: 'bad' })); //mock bad export shape
+      const loadQerrors = require('../lib/qerrorsLoader'); //import loader
+      expect(loadQerrors).toThrow('qerrors module does not export a callable function'); //assert error message
+    });
+  });
 });

--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -13,6 +13,9 @@ function loadQerrors() {
         try {
                 const mod = require('qerrors'); //import qerrors module
                 const qerrors = typeof mod === 'function' ? mod : mod.qerrors || mod.default; //resolve exported function
+                if (typeof qerrors !== 'function') { //verify resolved export is callable
+                        throw new Error('qerrors module does not export a callable function'); //throw explicit error when export invalid
+                }
                 logReturn('loadQerrors', qerrors.name); //log selected function name
                 return qerrors; //return callable qerrors function
         } catch (error) {


### PR DESCRIPTION
## Summary
- validate resolved export in qerrorsLoader and throw error if invalid
- add a test for invalid export shape

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68439e8ab9dc8322ae0fd4be393b27a5