### PR TITLE
Add DEBUG flag for conditional logging

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -11,6 +11,7 @@ const axios = require('axios');
 const Bottleneck = require('bottleneck'); // Rate limiting library to prevent API quota exhaustion
 const apiKey = process.env.GOOGLE_API_KEY; // Google API key from environment - required for authentication
 const cx = process.env.GOOGLE_CX; // Custom Search Engine ID from environment - defines search scope
+const DEBUG = /true/i.test(process.env.DEBUG); //flag to toggle verbose logging
 
 // qerrors is used to handle error reporting and logging with structured context
 const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
@@ -58,12 +59,12 @@ const limiter = new Bottleneck({
  */
 async function rateLimitedRequest(url) { //(handle network request with optional mock)
         const safeUrl = url.replace(apiKey, '[redacted]'); //(sanitize api key from url)
-        logStart('rateLimitedRequest', safeUrl); //(avoid key leak)
+        if (DEBUG) { logStart('rateLimitedRequest', safeUrl); } //(avoid key leak with toggle)
 
         if (String(process.env.CODEX).toLowerCase() === 'true') { //(use case-insensitive true check for codex mock)
                 const mockRes = { data: { items: [] } }; //(define mock axios-like response)
-                console.log('rateLimitedRequest using codex mock response'); //(notify mock path taken)
-                logReturn('rateLimitedRequest', JSON.stringify(mockRes)); //(mock return log)
+                if (DEBUG) { console.log('rateLimitedRequest using codex mock response'); } //(notify mock path taken when debug)
+                if (DEBUG) { logReturn('rateLimitedRequest', JSON.stringify(mockRes)); } //(mock return log when debug)
                 return mockRes; //(return mocked response)
         }
 
@@ -79,7 +80,7 @@ async function rateLimitedRequest(url) { //(handle network request with optional
                         }
                 })
         );
-        logReturn('rateLimitedRequest', JSON.stringify(res.data)); //(log real response)
+        if (DEBUG) { logReturn('rateLimitedRequest', `${res.status} ${Array.isArray(res.data.items) ? res.data.items.length : 0}`); } //(log status and item count when debug)
         return res; //(return axios response)
 }
 
@@ -123,7 +124,7 @@ function getGoogleURL(query) {
  * @returns {boolean} - true if error was handled successfully, false if handler itself failed
  */
 function handleAxiosError(error, contextMsg) {
-        logStart('handleAxiosError', contextMsg); //debug log for error handling flow
+        if (DEBUG) { logStart('handleAxiosError', contextMsg); } //debug log gated by DEBUG
 	
 	try {
 		// Check if error has a response (HTTP error) vs no response (network error)
@@ -141,14 +142,14 @@ function handleAxiosError(error, contextMsg) {
 		// This enables better error tracking and analysis across the application
 		qerrors(error, contextMsg, {contextMsg});
 		
-                logReturn('handleAxiosError', true); // Confirm successful error handling
+                if (DEBUG) { logReturn('handleAxiosError', true); } //log return when debug
                 return true; // Indicate error was handled successfully
 	} catch (err) {
                 // Error occurred within the error handler itself
                 // Attempt logging the secondary error and keep flow stable
                 try { qerrors(err, 'handleAxiosError error', {contextMsg}); } //log secondary error //(attempt qerrors)
                 catch (qe) { console.error(qe); } //fallback logging //(prevent crash)
-                logReturn('handleAxiosError', false); // Indicate handler failure
+                if (DEBUG) { logReturn('handleAxiosError', false); } //log failure when debug
                 return false; // Indicate error handling failed
         }
 }
@@ -163,12 +164,12 @@ function handleAxiosError(error, contextMsg) {
  * @throws {Error} If query is not a non-empty string
  */
 function validateSearchQuery(query) {
-        logStart('validateSearchQuery', query); //(start log of validation)
+        if (DEBUG) { logStart('validateSearchQuery', query); } //(start log when debug)
         if (typeof query !== 'string' || query.trim() === '') { //(check for non-empty string)
-                console.log('validateSearchQuery throwing Query must be a non-empty string'); //(log failure)
+                if (DEBUG) { console.log('validateSearchQuery throwing Query must be a non-empty string'); } //(log failure when debug)
                 throw new Error('Query must be a non-empty string'); //(throw on invalid input)
         }
-        logReturn('validateSearchQuery', true); //(log successful validation)
+        if (DEBUG) { logReturn('validateSearchQuery', true); } //(log success when debug)
         return true; //(confirm valid query)
 }
 
@@ -182,17 +183,17 @@ function validateSearchQuery(query) {
  * @returns {Promise<Array>} Raw items array from Google or empty array on error
  */
 async function fetchSearchItems(query) {
-        logStart('fetchSearchItems', query); //(start log of function execution)
+        if (DEBUG) { logStart('fetchSearchItems', query); } //(start log when debug)
         validateSearchQuery(query); //(reuse validation helper)
         try {
                 const url = getGoogleURL(query); //(build search url)
                 const response = await rateLimitedRequest(url); //(perform rate limited axios request)
                 const items = response.data.items || []; //(extract items array if present)
-                logReturn('fetchSearchItems', JSON.stringify(items)); //(log return value)
+                if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log return value when debug)
                 return items; //(return extracted items array)
         } catch (error) {
                 handleAxiosError(error, `Error in fetchSearchItems for query: ${query}`); //(handle and log any axios errors)
-                logReturn('fetchSearchItems', '[]'); //(log empty array due to failure)
+                if (DEBUG) { logReturn('fetchSearchItems', '[]'); } //(log empty array when debug)
                 return []; //(gracefully return empty array)
         }
 }
@@ -228,7 +229,7 @@ async function getTopSearchResults(searchTerms) {
 		return []; // Return empty array rather than failing - graceful degradation
 	}
 	
-        logStart('getTopSearchResults', validSearchTerms); //(log start with valid terms)
+        if (DEBUG) { logStart('getTopSearchResults', validSearchTerms); } //(log start when debug)
 	
 	// Use Promise.all() to execute all searches in parallel
 	// This is much faster than sequential execution, especially with rate limiting
@@ -238,14 +239,14 @@ async function getTopSearchResults(searchTerms) {
                 if (items.length > 0) { //(check for available results)
                         return items[0].link; //(return first result link)
                 }
-                console.log(`No results for "${query}"`); //(log when query yields nothing)
+                if (DEBUG) { console.log(`No results for "${query}"`); } //(log when query yields nothing in debug)
                 return null; //(indicate absence of result)
         }));
 	
 	// Filter out null values (failed searches or no results)
 	// This ensures the returned array contains only valid URLs
         const validUrls = searchResults.filter(url => url !== null);
-        logReturn('getTopSearchResults', validUrls); //(log return array of urls)
+        if (DEBUG) { logReturn('getTopSearchResults', validUrls); } //(log return array when debug)
         return validUrls; // Return array of strings (URLs only)
 }
 
@@ -265,14 +266,14 @@ async function getTopSearchResults(searchTerms) {
  */
 async function googleSearch(query) {
         validateSearchQuery(query); //(ensure non-empty string input)
-        logStart('googleSearch', query); //(start log of search)
+        if (DEBUG) { logStart('googleSearch', query); } //(start log when debug)
         const items = await fetchSearchItems(query); //(perform search via helper)
         const results = items.map(item => ({ //(map items to simplified objects)
                 title: item.title,
                 snippet: item.snippet,
                 link: item.link
         }));
-        logReturn('googleSearch', results.length); //(log number of results)
+        if (DEBUG) { logReturn('googleSearch', results.length); } //(log number when debug)
         return results;
 }
 


### PR DESCRIPTION
## Summary
- introduce a `DEBUG` flag in `qserp.js`
- log start/return and console output only when DEBUG is true
- log status and item count in `rateLimitedRequest`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684577c2bf248322bcb8a447bae7b5e6