### PR TITLE
Async qerrors with disable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ These variables enhance functionality but are not required:
 
 - `OPENAI_TOKEN` – Used by the `qerrors` dependency for enhanced error analysis and logging
 - `CODEX` – When set to any case-insensitive `true` value, enables offline mode with mocked responses
+- `QERRORS_DISABLE` – When set to any value, prevents `qerrors` from running
 
 ## Usage
 

--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -41,12 +41,13 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     expect(qerrors).toHaveBeenCalledTimes(1); //qerrors invoked once //(check)
   });
 
-  test('handles undefined variable array', () => { //verify undefined input //(third case)
+  test('handles undefined variable array', async () => { //verify undefined input //(third case)
     const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('../lib/envUtils'); //require utils fresh //(ensure env captured)
     expect(getMissingEnvVars(undefined)).toEqual([]); //returns empty array //(assert)
     expect(throwIfMissingEnvVars(undefined)).toEqual([]); //throws handled //(assert)
     expect(warnIfMissingEnvVars(undefined, 'warn')).toBe(true); //should not warn //(assert)
     expect(warnSpy).not.toHaveBeenCalled(); //warn not called //(check)
+    await new Promise(setImmediate); //wait for async qerrors
     expect(qerrors).toHaveBeenCalledTimes(3); //qerrors invoked three times //(check)
   });
 });

--- a/__tests__/integrationCombined.test.js
+++ b/__tests__/integrationCombined.test.js
@@ -30,6 +30,7 @@ describe('integration googleSearch and getTopSearchResults', () => { //describe 
     const urls = await getTopSearchResults(['Fail', 'Good']); //call multi search with one fail
     expect(searchRes).toEqual([]); //googleSearch should return empty array
     expect(urls).toEqual(['g']); //only successful url returned
+    await new Promise(setImmediate); //wait for async qerrors
     expect(scheduleMock).toHaveBeenCalledTimes(3); //schedule called for each attempt
     expect(qerrorsMock).toHaveBeenCalled(); //ensure qerrors invoked
   });

--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -53,6 +53,7 @@ describe('qserp module', () => { //group qserp tests
     mock.onGet(/customsearch/).reply(500); //mock failed request
     const res = await googleSearch('err'); //search expecting failure
     const urls = await getTopSearchResults(['err']); //multi search expecting failure
+    await new Promise(setImmediate); //wait for async qerrors
     expect(res).toEqual([]); //result should be empty array
     expect(urls).toEqual([]); //urls should be empty array
     expect(qerrorsMock).toHaveBeenCalled(); //qerrors should log error

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -3,21 +3,34 @@ const { createQerrorsMock } = require('./utils/testSetup'); //import qerrors moc
 const { safeRun } = require('../lib/utils'); //import function under test
 
 describe('safeRun', () => { //group safeRun tests
-  test('returns result when function succeeds', () => { //success branch
+  test('returns result when function succeeds', async () => { //success branch
     const qerrors = createQerrorsMock(); //reset qerrors mock
     const fn = jest.fn(() => 5); //mock function returning value
     const res = safeRun('testFn', fn, 0, { a: 1 }); //execute safeRun
+    await new Promise(setImmediate); //wait for async qerrors
     expect(res).toBe(5); //should return fn result
     expect(fn).toHaveBeenCalled(); //function called
     expect(qerrors).not.toHaveBeenCalled(); //qerrors unused
   });
 
-  test('returns default value and logs error when function throws', () => { //failure branch
+  test('returns default value and logs error when function throws', async () => { //failure branch
     const qerrors = createQerrorsMock(); //reset qerrors mock
     const fn = jest.fn(() => { throw new Error('fail'); }); //mock throwing fn
     const res = safeRun('badFn', fn, 1, { b: 2 }); //execute safeRun
+    await new Promise(setImmediate); //wait for async qerrors
     expect(res).toBe(1); //should return fallback
     expect(fn).toHaveBeenCalled(); //function called
     expect(qerrors).toHaveBeenCalledWith(expect.any(Error), 'badFn error', { b: 2 }); //qerrors invoked
+  });
+
+  test('does not call qerrors when QERRORS_DISABLE is set', async () => { //new disable check
+    process.env.QERRORS_DISABLE = '1'; //set flag
+    const qerrors = createQerrorsMock(); //reset qerrors mock
+    const fn = jest.fn(() => { throw new Error('fail'); }); //mock throwing fn
+    const res = safeRun('badFn', fn, 1, {}); //execute safeRun
+    await new Promise(setImmediate); //wait for async qerrors
+    expect(res).toBe(1); //should return fallback
+    expect(qerrors).not.toHaveBeenCalled(); //qerrors bypassed
+    delete process.env.QERRORS_DISABLE; //cleanup flag
   });
 });

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -137,17 +137,17 @@ function handleAxiosError(error, contextMsg) {
 			console.error(error.message);
 		}
 		
-		// Use qerrors for structured error logging with context
-		// This enables better error tracking and analysis across the application
-		qerrors(error, contextMsg, {contextMsg});
+                // Use qerrors asynchronously for structured error logging
+                if (!process.env.QERRORS_DISABLE) setImmediate(() => { try { qerrors(error, contextMsg, {contextMsg}); } catch (e) { console.error(e); } }); //(async qerrors call with catch)
 		
                 logReturn('handleAxiosError', true); // Confirm successful error handling
                 return true; // Indicate error was handled successfully
 	} catch (err) {
                 // Error occurred within the error handler itself
                 // Attempt logging the secondary error and keep flow stable
-                try { qerrors(err, 'handleAxiosError error', {contextMsg}); } //log secondary error //(attempt qerrors)
-                catch (qe) { console.error(qe); } //fallback logging //(prevent crash)
+                try {
+                        if (!process.env.QERRORS_DISABLE) setImmediate(() => { try { qerrors(err, 'handleAxiosError error', {contextMsg}); } catch (e) { console.error(e); } }); //(async secondary error logging with catch)
+                } catch (qe) { console.error(qe); } //fallback logging //(prevent crash)
                 logReturn('handleAxiosError', false); // Indicate handler failure
                 return false; // Indicate error handling failed
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,10 +53,9 @@ function safeRun(fnName, fn, defaultVal, context) {
 		return result; // Return the successful result
 		
 	} catch (error) {
-		// Handle any error that occurs during function execution
-		// Use qerrors for structured error logging with context
-		// This provides consistent error reporting across the application
-		qerrors(error, `${fnName} error`, context);
+                // Handle any error that occurs during function execution
+                // Use qerrors asynchronously for structured error logging
+                if (!process.env.QERRORS_DISABLE) setImmediate(() => { try { qerrors(error, `${fnName} error`, context); } catch (e) { console.error(e); } }); //(async qerrors call with catch)
 		
 		// Log the fallback value being returned
 		// This makes it clear in logs when fallback behavior is triggered


### PR DESCRIPTION
## Summary
- allow disabling `qerrors` via `QERRORS_DISABLE`
- run `qerrors` asynchronously in `safeRun` and `handleAxiosError`
- update tests for async error logging
- document new `QERRORS_DISABLE` option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684578d629148322b40ab92ac41b4c7a