### PR TITLE
Support search result count override

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,13 @@ Performs parallel searches for multiple terms and returns only the top result UR
 **Throws:**
 - `Error`: If searchTerms is not an array
 
-### fetchSearchItems(query)
+### fetchSearchItems(query, num)
 
-Fetches raw Google Custom Search API items for a query.
+Fetches raw Google Custom Search API items for a query. Optional `num` limits the number of returned items.
 
 **Parameters:**
 - `query` (string): The search query (must be non-empty)
+- `num` (number, optional): Maximum number of items to return
 
 **Returns:**
 - `Promise<Array>`: Raw items array from Google API or empty array on error

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -27,18 +27,21 @@ test('rateLimitedRequest rejects on axios failure and schedules call', async () 
   expect(scheduleMock).toHaveBeenCalled(); //ensure schedule invoked despite rejection
 });
 
-test('fetchSearchItems returns items and schedules call', async () => { //new helper test
+test('fetchSearchItems returns items and uses num argument', async () => { //ensure param passed
   mock.onGet(/term/).reply(200, { items: [{ link: 'x' }] }); //mock success using adapter
   const { fetchSearchItems } = require('../lib/qserp'); //load helper
-  const items = await fetchSearchItems('term'); //invoke helper
+  const items = await fetchSearchItems('term', 2); //invoke helper with num
   expect(items).toEqual([{ link: 'x' }]); //check items array
   expect(scheduleMock).toHaveBeenCalled(); //ensure schedule used
+  expect(mock.history.get[0].url).toBe('https://www.googleapis.com/customsearch/v1?q=term&key=key&cx=cx&num=2'); //url should include num
 });
 
 test('getGoogleURL builds proper url', () => {
   const { getGoogleURL } = require('../lib/qserp');
   const url = getGoogleURL('hello world');
   expect(url).toBe('https://www.googleapis.com/customsearch/v1?q=hello%20world&key=key&cx=cx');
+  const urlNum = getGoogleURL('hello', 5); //pass num argument
+  expect(urlNum).toBe('https://www.googleapis.com/customsearch/v1?q=hello&key=key&cx=cx&num=5'); //should include num param
 });
 
 test('handleAxiosError logs with qerrors and returns true', () => {

--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -41,6 +41,12 @@ describe('qserp module', () => { //group qserp tests
     expect(scheduleMock).toHaveBeenCalledTimes(2); //ensure rate limiter called twice
   });
 
+  test('getTopSearchResults requests single item', async () => { //ensure num param used
+    mock.onGet(/Solo/).reply(200, { items: [{ link: 'http://s' }] }); //mock single term
+    await getTopSearchResults(['Solo']); //call with one term
+    expect(mock.history.get[0].url).toBe('https://www.googleapis.com/customsearch/v1?q=Solo&key=key&cx=cx&num=1'); //url should request one item
+  });
+
   test('handles empty or invalid input', async () => { //verify validation paths
     await expect(googleSearch('')).rejects.toThrow(); //expect empty query throw
     await expect(fetchSearchItems('')).rejects.toThrow(); //expect empty query throw for helper

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -106,10 +106,11 @@ warnIfMissingEnvVars(OPTIONAL_VARS, OPENAI_WARN_MSG); //use centralized warning 
  * @throws {Error} If query contains characters that cannot be URL encoded
  * @private - Internal function used by public search functions
  */
-function getGoogleURL(query) {
-	// encodeURIComponent handles special characters, spaces, and Unicode properly
-	// This prevents URL malformation and ensures the query is interpreted correctly by Google
-	return `https://www.googleapis.com/customsearch/v1?q=${encodeURIComponent(query)}&key=${apiKey}&cx=${cx}`;
+function getGoogleURL(query, num) { //accept optional num argument to limit results
+        // encodeURIComponent handles special characters, spaces, and Unicode properly
+        // This prevents URL malformation and ensures the query is interpreted correctly by Google
+        const base = `https://www.googleapis.com/customsearch/v1?q=${encodeURIComponent(query)}&key=${apiKey}&cx=${cx}`; //base search url
+        return typeof num === 'number' ? `${base}&num=${num}` : base; //append num when provided
 }
 
 /**
@@ -182,11 +183,11 @@ function validateSearchQuery(query) {
  * @param {string} query - Search term to look up
  * @returns {Promise<Array>} Raw items array from Google or empty array on error
  */
-async function fetchSearchItems(query) {
+async function fetchSearchItems(query, num) { //accept optional num for result count
         if (DEBUG) { logStart('fetchSearchItems', query); } //(start log when debug)
         validateSearchQuery(query); //(reuse validation helper)
         try {
-                const url = getGoogleURL(query); //(build search url)
+                const url = getGoogleURL(query, num); //(build search url with optional num)
                 const response = await rateLimitedRequest(url); //(perform rate limited axios request)
                 const items = response.data.items || []; //(extract items array if present)
                 if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log return value when debug)
@@ -236,7 +237,7 @@ async function getTopSearchResults(searchTerms) {
 	// This is much faster than sequential execution, especially with rate limiting
 	// Each search is independent, so parallel execution is safe and beneficial
         const searchResults = await Promise.all(validSearchTerms.map(async (query) => {
-                const items = await fetchSearchItems(query); //(reuse helper for request)
+                const items = await fetchSearchItems(query, 1); //(fetch only one result per query)
                 if (items.length > 0) { //(check for available results)
                         return items[0].link; //(return first result link)
                 }


### PR DESCRIPTION
## Summary
- add optional `num` argument to `getGoogleURL`
- pass the count argument through `fetchSearchItems`
- request a single result in `getTopSearchResults`
- update tests for the new parameter
- document the new argument in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684670262aa08322949f4fbc6d8f89ef