### PR TITLE
Add debug flag utility and log gating

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -49,4 +49,14 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     expect(warnSpy).not.toHaveBeenCalled(); //warn not called //(check)
     expect(qerrors).toHaveBeenCalledTimes(3); //qerrors invoked three times //(check)
   });
+
+  test('does not log when DEBUG false', () => { //verify debug gating
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {}); //spy on console.log
+    delete process.env.DEBUG; //ensure debug flag unset
+    const { getMissingEnvVars } = require('../lib/envUtils'); //import after env set
+    const before = logSpy.mock.calls.length; //record initial log count
+    getMissingEnvVars([]); //call function expecting no logs
+    expect(logSpy.mock.calls.length).toBe(before); //no additional logs when debug off
+    logSpy.mockRestore(); //restore console.log
+  });
 });

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -20,4 +20,16 @@ describe('safeRun', () => { //group safeRun tests
     expect(fn).toHaveBeenCalled(); //function called
     expect(qerrors).toHaveBeenCalledWith(expect.any(Error), 'badFn error', { b: 2 }); //qerrors invoked
   });
+
+  test('does not log when DEBUG false', () => { //verify debug gating
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {}); //spy on console.log
+    delete process.env.DEBUG; //ensure debug flag unset
+    jest.resetModules(); //reload modules to pick up env change
+    const { safeRun } = require('../lib/utils'); //re-import after reset
+    const fn = jest.fn(() => 1); //simple function
+    const before = logSpy.mock.calls.length; //record initial log count
+    safeRun('noLog', fn, 0); //call expecting no logs
+    expect(logSpy.mock.calls.length).toBe(before); //no additional logs when debug off
+    logSpy.mockRestore(); //restore console.log
+  });
 });

--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -14,6 +14,8 @@
 const qerrors = require('./qerrorsLoader')(); //retrieve qerrors function via loader
 const { logStart, logReturn } = require('./logUtils'); //import standardized log utilities
 const { safeRun } = require('./utils'); //import safeRun utility for common error handling
+const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility
+const DEBUG = getDebugFlag(); //determine current debug state
 
 /**
  * Identifies which environment variables from a given list are missing
@@ -26,12 +28,12 @@ const { safeRun } = require('./utils'); //import safeRun utility for common erro
  * @returns {string[]} Array of missing variable names (empty if all present)
  */
 function getMissingEnvVars(varArr) {
-       logStart('getMissingEnvVars', varArr); //log start of function with provided vars
+       if (DEBUG) { logStart('getMissingEnvVars', varArr); } //log start only when debug enabled
 
        const missingArr = safeRun('getMissingEnvVars', () =>
                varArr.filter(name => !process.env[name]), [], { varArr }); //(filter safely)
 
-       logReturn('getMissingEnvVars', missingArr); //log function result
+       if (DEBUG) { logReturn('getMissingEnvVars', missingArr); } //log result only when debug enabled
        return missingArr; //return filtered array or fallback
 }
 
@@ -47,7 +49,7 @@ function getMissingEnvVars(varArr) {
  * @returns {string[]} Empty array if no variables are missing (for testing purposes)
  */
 function throwIfMissingEnvVars(varArr) {
-       logStart('throwIfMissingEnvVars', varArr); //log start of function with provided vars
+       if (DEBUG) { logStart('throwIfMissingEnvVars', varArr); } //log start only when debug enabled
 
        const missingEnvVars = getMissingEnvVars(varArr); //reuse detection utility
 
@@ -59,7 +61,7 @@ function throwIfMissingEnvVars(varArr) {
                throw err; //propagate failure
        }
 
-       logReturn('throwIfMissingEnvVars', missingEnvVars); //log function result
+       if (DEBUG) { logReturn('throwIfMissingEnvVars', missingEnvVars); } //log result only when debug enabled
        return missingEnvVars; //return array when all vars present
 }
 
@@ -75,7 +77,7 @@ function throwIfMissingEnvVars(varArr) {
  * @returns {boolean} True if all variables are present, otherwise false
  */
 function warnIfMissingEnvVars(varArr, customMessage = '') {
-       logStart('warnIfMissingEnvVars', varArr); //log start of function with provided vars
+       if (DEBUG) { logStart('warnIfMissingEnvVars', varArr); } //log start only when debug enabled
 
        const missingEnvVars = getMissingEnvVars(varArr); //reuse detection utility
 
@@ -86,7 +88,7 @@ function warnIfMissingEnvVars(varArr, customMessage = '') {
        }
 
        const result = missingEnvVars.length === 0; //determine if any vars missing //(compute boolean)
-       logReturn('warnIfMissingEnvVars', result); //log function result
+       if (DEBUG) { logReturn('warnIfMissingEnvVars', result); } //log result only when debug enabled
        return result; //inform caller if all vars present //(boolean instead of array)
 }
 

--- a/lib/getDebugFlag.js
+++ b/lib/getDebugFlag.js
@@ -1,0 +1,13 @@
+function getDebugFlag() {
+        console.log(`getDebugFlag is running with ${process.env.DEBUG}`); //log start with current DEBUG env
+        try {
+                const flag = /true/i.test(process.env.DEBUG); //compute case-insensitive boolean
+                console.log(`getDebugFlag is returning ${flag}`); //log computed flag
+                return flag; //return boolean
+        } catch (err) {
+                console.log(`getDebugFlag returning false`); //log fallback on error
+                return false; //fallback to false on error
+        }
+}
+
+module.exports = { getDebugFlag }; //export function for reuse

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -11,7 +11,8 @@ const axios = require('axios');
 const Bottleneck = require('bottleneck'); // Rate limiting library to prevent API quota exhaustion
 const apiKey = process.env.GOOGLE_API_KEY; // Google API key from environment - required for authentication
 const cx = process.env.GOOGLE_CX; // Custom Search Engine ID from environment - defines search scope
-const DEBUG = /true/i.test(process.env.DEBUG); //flag to toggle verbose logging
+const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility for consistent behavior
+const DEBUG = getDebugFlag(); //flag to toggle verbose logging
 
 // qerrors is used to handle error reporting and logging with structured context
 const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,6 +13,8 @@
 
 const qerrors = require('./qerrorsLoader')(); //import qerrors via loader to support varied export styles
 const { logStart, logReturn } = require('./logUtils'); // Import standardized logging utilities
+const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility
+const DEBUG = getDebugFlag(); //determine current debug state
 
 /**
  * Safely executes a function with error handling and fallback values
@@ -40,7 +42,7 @@ const { logStart, logReturn } = require('./logUtils'); // Import standardized lo
 function safeRun(fnName, fn, defaultVal, context) {
 	// Log the start of safe execution with context for debugging
 	// JSON.stringify handles the context object safely even if it contains complex data
-	logStart('safeRun', JSON.stringify({ fnName, context }));
+    if (DEBUG) { logStart('safeRun', JSON.stringify({ fnName, context })); } //log start when debug enabled
 	
 	try {
 		// Execute the provided function
@@ -49,7 +51,7 @@ function safeRun(fnName, fn, defaultVal, context) {
 		
 		// Log successful execution result for debugging
 		// This helps track when operations succeed vs when they fall back
-		logReturn('safeRun', result);
+                if (DEBUG) { logReturn('safeRun', result); } //log success when debug enabled
 		return result; // Return the successful result
 		
 	} catch (error) {
@@ -60,7 +62,7 @@ function safeRun(fnName, fn, defaultVal, context) {
 		
 		// Log the fallback value being returned
 		// This makes it clear in logs when fallback behavior is triggered
-		logReturn('safeRun', defaultVal);
+                if (DEBUG) { logReturn('safeRun', defaultVal); } //log fallback when debug enabled
 		return defaultVal; // Return the fallback value for graceful degradation
 	}
 }


### PR DESCRIPTION
## Summary
- add `getDebugFlag` helper for consistent DEBUG logic
- gate log statements in `envUtils.js` and `utils.js`
- use debug flag in `qserp.js`
- ensure tests cover new logging behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684670343f6c83228f4f44bd4d951bae