### PR TITLE
Lazy-load qerrors handler

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -13,8 +13,14 @@ const apiKey = process.env.GOOGLE_API_KEY; // Google API key from environment - 
 const cx = process.env.GOOGLE_CX; // Custom Search Engine ID from environment - defines search scope
 const DEBUG = /true/i.test(process.env.DEBUG); //flag to toggle verbose logging
 
-// qerrors is used to handle error reporting and logging with structured context
-const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
+// qerrors will be loaded lazily on first error
+let cachedQerrors; //holds loaded qerrors function //(cache container)
+function getQerrors() { //(retrieve cached qerrors on demand)
+        if (!cachedQerrors) { //(first error triggers load)
+                cachedQerrors = require('./qerrorsLoader')(); //(load and cache qerrors)
+        }
+        return cachedQerrors; //(return cached function)
+} //end getQerrors helper
 const { logStart, logReturn } = require('./logUtils'); //standardized logging utilities
 
 // Import utility functions for environment variable validation
@@ -138,16 +144,16 @@ function handleAxiosError(error, contextMsg) {
 			console.error(error.message);
 		}
 		
-		// Use qerrors for structured error logging with context
-		// This enables better error tracking and analysis across the application
-		qerrors(error, contextMsg, {contextMsg});
+                // Use qerrors for structured error logging with context
+                // Lazy loading ensures qerrors only initializes on demand
+                getQerrors()(error, contextMsg, {contextMsg}); //(call cached qerrors)
 		
                 if (DEBUG) { logReturn('handleAxiosError', true); } //log return when debug
                 return true; // Indicate error was handled successfully
 	} catch (err) {
                 // Error occurred within the error handler itself
                 // Attempt logging the secondary error and keep flow stable
-                try { qerrors(err, 'handleAxiosError error', {contextMsg}); } //log secondary error //(attempt qerrors)
+                try { getQerrors()(err, 'handleAxiosError error', {contextMsg}); } //log secondary error with cached qerrors //(attempt qerrors)
                 catch (qe) { console.error(qe); } //fallback logging //(prevent crash)
                 if (DEBUG) { logReturn('handleAxiosError', false); } //log failure when debug
                 return false; // Indicate error handling failed

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,7 +11,13 @@
  * the entire application when non-critical operations fail.
  */
 
-const qerrors = require('./qerrorsLoader')(); //import qerrors via loader to support varied export styles
+let cachedQerrors; //cache for lazy-loaded qerrors //(holds function)
+function getQerrors() { //(return cached qerrors function)
+        if (!cachedQerrors) { //(only load once)
+                cachedQerrors = require('./qerrorsLoader')(); //(load qerrors module)
+        }
+        return cachedQerrors; //(provide function to caller)
+} //end getQerrors helper
 const { logStart, logReturn } = require('./logUtils'); // Import standardized logging utilities
 
 /**
@@ -56,7 +62,7 @@ function safeRun(fnName, fn, defaultVal, context) {
 		// Handle any error that occurs during function execution
 		// Use qerrors for structured error logging with context
 		// This provides consistent error reporting across the application
-		qerrors(error, `${fnName} error`, context);
+                getQerrors()(error, `${fnName} error`, context); //(log lazily loaded qerrors)
 		
 		// Log the fallback value being returned
 		// This makes it clear in logs when fallback behavior is triggered


### PR DESCRIPTION
## Summary
- remove eager qerrors initialization
- add lazy `getQerrors` helper
- adjust utilities and tests for dynamic loading

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684670476c848322906b3595f4f004b6