### PR TITLE
Add keep-alive axios instance

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -20,6 +20,18 @@ test('rateLimitedRequest calls limiter and sets headers', async () => {
   expect(config['User-Agent']).toMatch(/Mozilla/);
 });
 
+test('rateLimitedRequest uses custom axios instance', async () => { //verify instance path
+  mock.onGet('http://inst').reply(200, {}); //mock via instance
+  const { rateLimitedRequest, axiosInstance } = require('../lib/qserp');
+  const globalSpy = jest.spyOn(require('axios'), 'get'); //spy default axios
+  const instSpy = jest.spyOn(axiosInstance, 'get'); //spy instance
+  await rateLimitedRequest('http://inst'); //trigger request
+  expect(instSpy).toHaveBeenCalled(); //instance should handle call
+  expect(globalSpy).not.toHaveBeenCalled(); //default axios unused
+  globalSpy.mockRestore(); //cleanup spies
+  instSpy.mockRestore();
+});
+
 test('rateLimitedRequest rejects on axios failure and schedules call', async () => {
   mock.onGet('http://bad').networkError(); //simulate network error
   const { rateLimitedRequest } = require('../lib/qserp');

--- a/__tests__/utils/testSetup.js
+++ b/__tests__/utils/testSetup.js
@@ -48,10 +48,10 @@ function createQerrorsMock() {
   return qerrorsMock; //export qerrors mock
 }
 
-function createAxiosMock() {
+function createAxiosMock(instance) {
   logStart('createAxiosMock', 'none'); //initial log via util
   const MockAdapter = require('axios-mock-adapter'); //import mock adapter
-  const axios = require('axios'); //import axios instance
+  const axios = instance || require('axios'); //use provided instance or default
   const mock = new MockAdapter(axios); //create adapter instance
   logReturn('createAxiosMock', 'adapter'); //final log via util
   return mock; //export axios mock
@@ -72,7 +72,8 @@ function initSearchTest() { //helper to init env and mocks
   setTestEnv(); //prepare environment variables
   const scheduleMock = createScheduleMock(); //create schedule mock
   const qerrorsMock = createQerrorsMock(); //create qerrors mock
-  const mock = createAxiosMock(); //create axios mock
+  const qserp = require('../../lib/qserp'); //load module for axios instance
+  const mock = createAxiosMock(qserp.axiosInstance); //create adapter for instance
   logReturn('initSearchTest', 'mocks'); //final log via util
   return { mock, scheduleMock, qerrorsMock }; //return configured mocks
 }

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -8,6 +8,12 @@
  */
 
 const axios = require('axios');
+const http = require('http'); //node http module for custom agent
+const https = require('https'); //node https module for custom agent
+const axiosInstance = axios.create({ //axios instance with keepAlive agents
+        httpAgent: new http.Agent({ keepAlive: true }), //reuse http sockets
+        httpsAgent: new https.Agent({ keepAlive: true }) //reuse https sockets
+});
 const Bottleneck = require('bottleneck'); // Rate limiting library to prevent API quota exhaustion
 const apiKey = process.env.GOOGLE_API_KEY; // Google API key from environment - required for authentication
 const cx = process.env.GOOGLE_CX; // Custom Search Engine ID from environment - defines search scope
@@ -70,8 +76,8 @@ async function rateLimitedRequest(url) { //(handle network request with optional
 
         // Use limiter.schedule to automatically handle rate limiting
         // This returns a promise that resolves when the request is allowed to proceed
-        const res = await limiter.schedule(() =>
-                axios.get(url, {
+        const res = await limiter.schedule(() => //use configured axios instance
+                axiosInstance.get(url, {
                         timeout: 10000, // 10 second timeout to prevent hanging requests
                         headers: {
                                 // User-Agent header mimics Chrome browser to avoid bot detection
@@ -301,4 +307,5 @@ module.exports = {
         getGoogleURL,           // URL builder for Google API
         handleAxiosError        // Centralized error handler
        , validateSearchQuery    // Validation helper for query strings //(export validation function)
+       , axiosInstance          // Expose configured axios instance for tests
 };


### PR DESCRIPTION
## Summary
- create an axios instance configured with keep-alive HTTP(S) agents
- update rateLimitedRequest to use that axios instance
- export the instance for testing
- adjust test utilities to mock the new instance
- verify the instance is used in internal functions tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68467070891c8322a2113d2bc78e4bf6