### PR TITLE
Remove duplicate validation

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -266,8 +266,7 @@ async function getTopSearchResults(searchTerms) {
  * @throws {Error} If query is not a string or is empty
  */
 async function googleSearch(query) {
-        validateSearchQuery(query); //(ensure non-empty string input)
-        if (DEBUG) { logStart('googleSearch', query); } //(start log when debug)
+        if (DEBUG) { logStart('googleSearch', query); } //(start log; validation occurs in fetchSearchItems)
         const items = await fetchSearchItems(query); //(perform search via helper)
         const results = items.map(item => ({ //(map items to simplified objects)
                 title: item.title,


### PR DESCRIPTION
## Summary
- call `validateSearchQuery` only within `fetchSearchItems`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6846707881f88322a4448b53bc3793eb