### PR TITLE
Use LRU cache for search results

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -20,9 +20,10 @@ const cx = process.env.GOOGLE_CX; // Custom Search Engine ID from environment - 
 const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility for consistent behavior
 const DEBUG = getDebugFlag(); //flag to toggle verbose logging
 
-// In-memory cache storing recent query results with timestamps //(store items for ttl reuse)
-const cache = new Map(); //{ query -> { timestamp, items } }
+// Use lru-cache for automatic expiry and size limit //(replace Map cache)
+const LRU = require('lru-cache'); //module providing LRU caching
 const CACHE_TTL = 300000; //5 minute cache lifespan in ms
+const cache = new LRU({ max: 500, maxAge: CACHE_TTL }); //cache instance with limits
 
 // qerrors is used to handle error reporting and logging with structured context
 const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
@@ -199,24 +200,19 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
         validateSearchQuery(query); //(reuse validation helper)
         try {
 
-                const now = Date.now(); //capture current time for ttl checks
-                const cached = cache.get(query); //lookup existing cache entry
-                if (cached && now - cached.timestamp < CACHE_TTL) { //return if within ttl
-                        if (DEBUG) { console.log('fetchSearchItems returning cached'); } //(log cache hit)
-                        logReturn('fetchSearchItems', JSON.stringify(cached.items)); //(log cached return)
-                        return cached.items; //use cached array
-                }
-
-                for (const [key, entry] of cache) { //iterate for expired entries
-                        if (now - entry.timestamp >= CACHE_TTL) { cache.delete(key); } //clear stale cache
-                }
+               const cached = cache.get(query); //lookup existing cache entry
+               if (cached) { //return if item is cached
+                       if (DEBUG) { console.log('fetchSearchItems returning cached'); } //(log cache hit)
+                       logReturn('fetchSearchItems', JSON.stringify(cached)); //(log cached return)
+                       return cached; //use cached array
+               }
 
 
                 const url = getGoogleURL(query, num); //(build search url with optional num)
 
                 const response = await rateLimitedRequest(url); //(perform rate limited axios request)
-                const items = response.data.items || []; //(extract items array if present)
-                cache.set(query, { timestamp: now, items }); //store results with timestamp
+               const items = response.data.items || []; //(extract items array if present)
+               cache.set(query, items); //store results in LRU cache
                 if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log return value when debug)
                 return items; //(return extracted items array)
         } catch (error) {
@@ -234,8 +230,8 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
  * @returns {boolean} true when cache cleared
  */
 function clearCache() {
-        logStart('clearCache', cache.size); //(log current cache size)
-        cache.clear(); //(remove all cached entries)
+        logStart('clearCache', cache.itemCount); //(log current cache size)
+        cache.reset(); //(remove all cached entries)
         logReturn('clearCache', true); //(log completion)
         return true; //(confirm cleared)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^1.2.0",
         "bottleneck": "^2.19.5",
+        "lru-cache": "^6.0.0",
         "qerrors": "^1.2.0",
         "qtests": "^1.0.2"
       },
@@ -115,6 +116,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-module-imports": {
@@ -2971,13 +2981,22 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "license": "ISC",
       "dependencies": {
-        "yallist": "^3.0.2"
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
+    },
+    "node_modules/lru-cache/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -4056,6 +4075,16 @@
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        }
       }
     },
     "@babel/helper-module-imports": {
@@ -5986,11 +6015,18 @@
       }
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
-        "yallist": "^3.0.2"
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
       }
     },
     "make-dir": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "axios": "^1.2.0",
     "bottleneck": "^2.19.5",
+    "lru-cache": "^6.0.0",
     "qerrors": "^1.2.0",
     "qtests": "^1.0.2"
   },


### PR DESCRIPTION
## Summary
- add `lru-cache` dependency
- replace old `Map` cache with LRU cache
- drop manual expiry loop
- adjust clearCache helper for LRU

## Testing
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_b_68468a207a7c8322afe8bb049473ca0e