### PR TITLE
Implement pending request dedupe

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -23,6 +23,7 @@ const DEBUG = getDebugFlag(); //flag to toggle verbose logging
 // In-memory cache storing recent query results with timestamps //(store items for ttl reuse)
 const cache = new Map(); //{ query -> { timestamp, items } }
 const CACHE_TTL = 300000; //5 minute cache lifespan in ms
+const pending = new Map(); //store unresolved requests for deduping
 
 // qerrors is used to handle error reporting and logging with structured context
 const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
@@ -212,11 +213,20 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                 }
 
 
+                if (pending.has(query)) { //dedupe concurrent requests
+                        if (DEBUG) { console.log('fetchSearchItems awaiting pending'); } //(log pending hit)
+                        const pendingItems = await pending.get(query); //wait for existing promise
+                        logReturn('fetchSearchItems', JSON.stringify(pendingItems)); //(log pending return)
+                        return pendingItems; //return resolved items
+                }
+
                 const url = getGoogleURL(query, num); //(build search url with optional num)
 
-                const response = await rateLimitedRequest(url); //(perform rate limited axios request)
-                const items = response.data.items || []; //(extract items array if present)
-                cache.set(query, { timestamp: now, items }); //store results with timestamp
+                const requestPromise = rateLimitedRequest(url) //initiate request
+                        .then(res => { const items = res.data.items || []; cache.set(query, { timestamp: Date.now(), items }); return items; }) //cache and return items
+                        .finally(() => { pending.delete(query); }); //cleanup pending map
+                pending.set(query, requestPromise); //store promise for dedupe
+                const items = await requestPromise; //await resolved items
                 if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log return value when debug)
                 return items; //(return extracted items array)
         } catch (error) {


### PR DESCRIPTION
## Summary
- avoid duplicate fetches by tracking pending requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68468a2578a4832285a9813c5a7a6196