### PR TITLE
Update Google URL builder

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -45,15 +45,15 @@ test('fetchSearchItems returns items and uses num argument', async () => { //ens
   const items = await fetchSearchItems('term', 2); //invoke helper with num
   expect(items).toEqual([{ link: 'x' }]); //check items array
   expect(scheduleMock).toHaveBeenCalled(); //ensure schedule used
-  expect(mock.history.get[0].url).toBe('https://www.googleapis.com/customsearch/v1?q=term&key=key&cx=cx&num=2'); //url should include num
+  expect(mock.history.get[0].url).toBe('https://www.googleapis.com/customsearch/v1?q=term&key=key&cx=cx&fields=items(title,snippet,link)&num=2'); //url should include num and fields filter
 });
 
 test('getGoogleURL builds proper url', () => {
   const { getGoogleURL } = require('../lib/qserp');
   const url = getGoogleURL('hello world');
-  expect(url).toBe('https://www.googleapis.com/customsearch/v1?q=hello%20world&key=key&cx=cx');
+  expect(url).toBe('https://www.googleapis.com/customsearch/v1?q=hello%20world&key=key&cx=cx&fields=items(title,snippet,link)');
   const urlNum = getGoogleURL('hello', 5); //pass num argument
-  expect(urlNum).toBe('https://www.googleapis.com/customsearch/v1?q=hello&key=key&cx=cx&num=5'); //should include num param
+  expect(urlNum).toBe('https://www.googleapis.com/customsearch/v1?q=hello&key=key&cx=cx&fields=items(title,snippet,link)&num=5'); //should include num param and fields filter
 });
 
 test('handleAxiosError logs with qerrors and returns true', () => {

--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -45,7 +45,7 @@ describe('qserp module', () => { //group qserp tests
   test('getTopSearchResults requests single item', async () => { //ensure num param used
     mock.onGet(/Solo/).reply(200, { items: [{ link: 'http://s' }] }); //mock single term
     await getTopSearchResults(['Solo']); //call with one term
-    expect(mock.history.get[0].url).toBe('https://www.googleapis.com/customsearch/v1?q=Solo&key=key&cx=cx&num=1'); //url should request one item
+    expect(mock.history.get[0].url).toBe('https://www.googleapis.com/customsearch/v1?q=Solo&key=key&cx=cx&fields=items(title,snippet,link)&num=1'); //url should request one item with fields filter
   });
 
   test('handles empty or invalid input', async () => { //verify validation paths

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -120,7 +120,7 @@ warnIfMissingEnvVars(OPTIONAL_VARS, OPENAI_WARN_MSG); //use centralized warning 
 function getGoogleURL(query, num) { //accept optional num argument to limit results
         // encodeURIComponent handles special characters, spaces, and Unicode properly
         // This prevents URL malformation and ensures the query is interpreted correctly by Google
-        const base = `https://www.googleapis.com/customsearch/v1?q=${encodeURIComponent(query)}&key=${apiKey}&cx=${cx}`; //base search url
+        const base = `https://www.googleapis.com/customsearch/v1?q=${encodeURIComponent(query)}&key=${apiKey}&cx=${cx}&fields=items(title,snippet,link)`; //add fields filter to reduce payload
         return typeof num === 'number' ? `${base}&num=${num}` : base; //append num when provided
 }
 


### PR DESCRIPTION
## Summary
- filter Google API fields to reduce payload size
- adjust tests to expect the fields query parameter

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68468a2c00ac8322b32457c39aa9b810