### PR TITLE
Update axios agent options

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -10,9 +10,9 @@
 const axios = require('axios');
 const http = require('http'); //node http module for custom agent
 const https = require('https'); //node https module for custom agent
-const axiosInstance = axios.create({ //axios instance with keepAlive agents
-        httpAgent: new http.Agent({ keepAlive: true }), //reuse http sockets
-        httpsAgent: new https.Agent({ keepAlive: true }) //reuse https sockets
+const axiosInstance = axios.create({ //axios instance with keepAlive agents and socket limits
+        httpAgent: new http.Agent({ keepAlive: true, maxSockets: 20, maxFreeSockets: 10 }), //reuse http sockets with connection limits
+        httpsAgent: new https.Agent({ keepAlive: true, maxSockets: 20, maxFreeSockets: 10 }) //reuse https sockets with connection limits
 });
 const Bottleneck = require('bottleneck'); // Rate limiting library to prevent API quota exhaustion
 const apiKey = process.env.GOOGLE_API_KEY; // Google API key from environment - required for authentication


### PR DESCRIPTION
## Summary
- limit socket counts for axios HTTP and HTTPS agents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68468a30af1c8322ae1446ee85133310