### PR TITLE
Update debug logging guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ These variables enhance functionality but are not required:
 
 - `OPENAI_TOKEN` – Used by the `qerrors` dependency for enhanced error analysis and logging
 - `CODEX` – When set to any case-insensitive `true` value, enables offline mode with mocked responses
+- `DEBUG` – Enables verbose logging when set. Leave unset in production for quieter output
 
 ## Usage
 

--- a/lib/getDebugFlag.js
+++ b/lib/getDebugFlag.js
@@ -1,11 +1,12 @@
 function getDebugFlag() {
-        console.log(`getDebugFlag is running with ${process.env.DEBUG}`); //log start with current DEBUG env
+        const envValue = process.env.DEBUG; //capture DEBUG env value for checks
+        const debugFlag = /true/i.test(envValue); //determine debug boolean from env
+        if (debugFlag) { console.log(`getDebugFlag is running with ${envValue}`); } //log start only when debug
         try {
-                const flag = /true/i.test(process.env.DEBUG); //compute case-insensitive boolean
-                console.log(`getDebugFlag is returning ${flag}`); //log computed flag
-                return flag; //return boolean
+                if (debugFlag) { console.log(`getDebugFlag is returning ${debugFlag}`); } //log result when debug
+                return debugFlag; //return computed flag
         } catch (err) {
-                console.log(`getDebugFlag returning false`); //log fallback on error
+                if (debugFlag) { console.log(`getDebugFlag returning false`); } //log fallback when debug
                 return false; //fallback to false on error
         }
 }

--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -7,16 +7,18 @@
  */
 
 const { logStart, logReturn } = require('./logUtils'); //import standardized logging utilities
+const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility for conditional logs
+const DEBUG = getDebugFlag(); //determine current debug state
 
 function loadQerrors() {
-        logStart('loadQerrors', 'qerrors module'); //log start before require
+        if (DEBUG) { logStart('loadQerrors', 'qerrors module'); } //log start when debug
         try {
                 const mod = require('qerrors'); //import qerrors module
                 const qerrors = typeof mod === 'function' ? mod : mod.qerrors || mod.default; //resolve exported function
                 if (typeof qerrors !== 'function') { //verify resolved export is callable
                         throw new Error('qerrors module does not export a callable function'); //throw explicit error when export invalid
                 }
-                logReturn('loadQerrors', qerrors.name); //log selected function name
+                if (DEBUG) { logReturn('loadQerrors', qerrors.name); } //log function name when debug
                 return qerrors; //return callable qerrors function
         } catch (error) {
                 console.error(error); //log loader failure

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -203,7 +203,7 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                 const cached = cache.get(query); //lookup existing cache entry
                 if (cached && now - cached.timestamp < CACHE_TTL) { //return if within ttl
                         if (DEBUG) { console.log('fetchSearchItems returning cached'); } //(log cache hit)
-                        logReturn('fetchSearchItems', JSON.stringify(cached.items)); //(log cached return)
+                        if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(cached.items)); } //log cached items when debug
                         return cached.items; //use cached array
                 }
 
@@ -234,9 +234,9 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
  * @returns {boolean} true when cache cleared
  */
 function clearCache() {
-        logStart('clearCache', cache.size); //(log current cache size)
+        if (DEBUG) { logStart('clearCache', cache.size); } //log size when debug
         cache.clear(); //(remove all cached entries)
-        logReturn('clearCache', true); //(log completion)
+        if (DEBUG) { logReturn('clearCache', true); } //log completion when debug
         return true; //(confirm cleared)
 }
 


### PR DESCRIPTION
## Summary
- guard debug console output in `getDebugFlag`
- add debug checks to `qerrorsLoader`
- prevent cache clear logs unless DEBUG is set
- only log cached fetch results when DEBUG is enabled
- mention that DEBUG should remain unset in production

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68468a340a64832297bf3c8278585dbe