### PR TITLE
Use ttl for lru-cache expiry

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -23,7 +23,7 @@ const DEBUG = getDebugFlag(); //flag to toggle verbose logging
 // Use lru-cache for automatic expiry and size limit //(replace Map cache)
 const LRU = require('lru-cache'); //module providing LRU caching
 const CACHE_TTL = 300000; //5 minute cache lifespan in ms
-const cache = new LRU({ max: 500, maxAge: CACHE_TTL }); //cache instance with limits
+const cache = new LRU({ max: 500, ttl: CACHE_TTL }); //cache instance with limits; ttl required for automatic expiry
 
 // qerrors is used to handle error reporting and logging with structured context
 const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader


### PR DESCRIPTION
## Summary
- use `ttl` when creating LRU cache for automatic expiry
- clarify TTL comment

## Testing
- `npm test` *(fails: 1 failed, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_b_684691fca5988322b745b8f767bf0b69