### PR TITLE
Update cache key for fetchSearchItems

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -126,4 +126,15 @@ describe('qserp module', () => { //group qserp tests
     expect(scheduleMock).toHaveBeenCalled(); //new request scheduled
     Date.now.mockRestore(); //restore Date.now
   });
+
+  test('fetchSearchItems caches per num value', async () => { //ensure num forms part of cache key
+    mock.onGet(/NumKey/).reply(200, { items: [{ link: '1' }] }); //mock first request
+    const first = await fetchSearchItems('NumKey', 1); //populate cache with num=1
+    scheduleMock.mockClear(); //reset schedule count
+    mock.onGet(/NumKey/).reply(200, { items: [{ link: '2' }] }); //mock second call with different num
+    const second = await fetchSearchItems('NumKey', 2); //should fetch again due to different key
+    expect(first).toEqual([{ link: '1' }]); //ensure first results
+    expect(second).toEqual([{ link: '2' }]); //expect second results not cached
+    expect(scheduleMock).toHaveBeenCalled(); //new request should occur
+  });
 });

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -193,6 +193,7 @@ function validateSearchQuery(query) {
  * only the raw items array from Google is needed by other functions.
  *
  * @param {string} query - Search term to look up
+ * @param {number} [num] - Optional number of results to request; part of cache key
  * @returns {Promise<Array>} Raw items array from Google or empty array on error
  */
 async function fetchSearchItems(query, num) { //accept optional num for result count
@@ -200,7 +201,8 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
         validateSearchQuery(query); //(reuse validation helper)
         try {
 
-               const cached = cache.get(query); //lookup existing cache entry
+               const cacheKey = num ? `${query}:${num}` : query; //use num in key so cached result counts stay separate
+               const cached = cache.get(cacheKey); //lookup existing cache entry
                if (cached) { //return if item is cached
                        if (DEBUG) { console.log('fetchSearchItems returning cached'); } //(log cache hit)
                        logReturn('fetchSearchItems', JSON.stringify(cached)); //(log cached return)
@@ -212,7 +214,7 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
 
                 const response = await rateLimitedRequest(url); //(perform rate limited axios request)
                const items = response.data.items || []; //(extract items array if present)
-               cache.set(query, items); //store results in LRU cache
+               cache.set(cacheKey, items); //store results in LRU cache keyed by query and result count
                 if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log return value when debug)
                 return items; //(return extracted items array)
         } catch (error) {


### PR DESCRIPTION
## Summary
- make fetchSearchItems cache key include `num`
- test cache key behavior when requesting different `num`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6846920125d48322a40ae35b5657d8c6