### PR TITLE
Add compression header for Google search

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ A robust Node.js module for performing Google Custom Searches using the Google C
 - **Parallel Processing**: Support for multiple concurrent searches with optimal performance
 - **Input Validation**: Robust validation of search queries and parameters
 - **Detailed Logging**: Optional detailed execution logging for debugging
+- **Compressed Responses**: Google supports gzip/deflate/br and the module requests them
+
+Google's API automatically compresses responses when `Accept-Encoding` includes `gzip`, `deflate`, or `br`. The library sets this header on all requests so payloads are smaller and parsing stays transparent.
 
 ## Installation
 

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -11,8 +11,9 @@ const axios = require('axios');
 const http = require('http'); //node http module for custom agent
 const https = require('https'); //node https module for custom agent
 const axiosInstance = axios.create({ //axios instance with keepAlive agents and socket limits
-        httpAgent: new http.Agent({ keepAlive: true, maxSockets: 20, maxFreeSockets: 10 }), //reuse http sockets with connection limits
-        httpsAgent: new https.Agent({ keepAlive: true, maxSockets: 20, maxFreeSockets: 10 }) //reuse https sockets with connection limits
+       headers: { 'Accept-Encoding': 'gzip, deflate, br' }, //request compressed responses for smaller payloads
+       httpAgent: new http.Agent({ keepAlive: true, maxSockets: 20, maxFreeSockets: 10 }), //reuse http sockets with connection limits
+       httpsAgent: new https.Agent({ keepAlive: true, maxSockets: 20, maxFreeSockets: 10 }) //reuse https sockets with connection limits
 });
 const Bottleneck = require('bottleneck'); // Rate limiting library to prevent API quota exhaustion
 const apiKey = process.env.GOOGLE_API_KEY; // Google API key from environment - required for authentication


### PR DESCRIPTION
## Summary
- request compressed responses in axios instance
- document that Google supports compressed results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684692042c8c8322b99b151607c6e8b6