### PR TITLE
Add log level aware logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ These variables enhance functionality but are not required:
 
 - `OPENAI_TOKEN` – Used by the `qerrors` dependency for enhanced error analysis and logging
 - `CODEX` – When set to any case-insensitive `true` value, enables offline mode with mocked responses
+- `LOG_LEVEL` – Controls `warn` and `error` output (`info` by default)
 
 ## Usage
 

--- a/__tests__/minLogger.test.js
+++ b/__tests__/minLogger.test.js
@@ -1,0 +1,35 @@
+const { mockConsole } = require('./utils/consoleSpies'); //reuse console spy helper
+const { saveEnv, restoreEnv } = require('./utils/testSetup'); //env helpers
+
+describe('minLogger', () => {
+  let savedEnv; //snapshot holder
+  beforeEach(() => { savedEnv = saveEnv(); }); //store env
+  afterEach(() => { restoreEnv(savedEnv); }); //restore env
+
+  test('logWarn respects LOG_LEVEL warn', () => { //warn should log
+    process.env.LOG_LEVEL = 'warn'; //set level
+    const spy = mockConsole('warn'); //spy on console.warn
+    const { logWarn } = require('../lib/minLogger'); //import function
+    logWarn('a'); //call logger
+    expect(spy).toHaveBeenCalledWith('a'); //should log
+    spy.mockRestore(); //cleanup spy
+  });
+
+  test('logWarn suppressed when LOG_LEVEL error', () => { //warn not logged
+    process.env.LOG_LEVEL = 'error'; //error only
+    const spy = mockConsole('warn'); //spy on console.warn
+    const { logWarn } = require('../lib/minLogger'); //import function
+    logWarn('a'); //call logger
+    expect(spy).not.toHaveBeenCalled(); //should not log
+    spy.mockRestore(); //cleanup
+  });
+
+  test('logError always logs at error level', () => { //error should log
+    process.env.LOG_LEVEL = 'warn'; //level permits error
+    const spy = mockConsole('error'); //spy on console.error
+    const { logError } = require('../lib/minLogger'); //import function
+    logError('bad'); //call logger
+    expect(spy).toHaveBeenCalledWith('bad'); //should log
+    spy.mockRestore(); //cleanup
+  });
+});

--- a/lib/minLogger.js
+++ b/lib/minLogger.js
@@ -1,0 +1,52 @@
+
+/**
+ * minLogger.js - Minimal logging utility honoring LOG_LEVEL env
+ *
+ * Provides simple warn and error logging that can be disabled via environment
+ * configuration. LOG_LEVEL accepts 'info', 'warn', 'error', or 'silent'.
+ */
+
+const levelRank = { error: 0, warn: 1, info: 2, silent: 3 }; //rank map for levels
+
+function shouldLog(level) {
+        console.log(`shouldLog is running with ${level}`); //trace function start
+        try {
+                const envLevel = String(process.env.LOG_LEVEL || 'info').toLowerCase(); //get env level
+                const result = levelRank[level] <= levelRank[envLevel]; //determine allowance
+                console.log(`shouldLog is returning ${result}`); //trace result
+                return result; //return boolean decision
+        } catch (err) {
+                console.log(`shouldLog returning false`); //trace failure path
+                return false; //default to no log on error
+        }
+}
+
+function logWarn(msg) {
+        console.log(`logWarn is running with ${msg}`); //trace run with message
+        try {
+                if (shouldLog('warn')) { //respect LOG_LEVEL for warnings
+                        console.warn(msg); //emit warning when allowed
+                }
+                console.log(`logWarn is returning true`); //trace successful end
+                return true; //confirm execution
+        } catch (err) {
+                console.log(`logWarn returning false`); //trace failure path
+                return false; //indicate failure
+        }
+}
+
+function logError(msg) {
+        console.log(`logError is running with ${msg}`); //trace run with message
+        try {
+                if (shouldLog('error')) { //respect LOG_LEVEL for errors
+                        console.error(msg); //emit error when allowed
+                }
+                console.log(`logError is returning true`); //trace successful end
+                return true; //confirm execution
+        } catch (err) {
+                console.log(`logError returning false`); //trace failure path
+                return false; //indicate failure
+        }
+}
+
+module.exports = { logWarn, logError }; //export logging functions

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -28,6 +28,7 @@ const cache = new LRU({ max: 500, maxAge: CACHE_TTL }); //cache instance with li
 // qerrors is used to handle error reporting and logging with structured context
 const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
 const { logStart, logReturn } = require('./logUtils'); //standardized logging utilities
+const { logWarn, logError } = require('./minLogger'); //minimal log utility for warn/error
 
 // Import utility functions for environment variable validation
 // These utilities centralize env var handling to avoid repetitive validation code
@@ -144,11 +145,11 @@ function handleAxiosError(error, contextMsg) {
 		if (error.response) {
 			// HTTP error: server responded with error status code
 			// Log the full response object which contains status, headers, and data
-			console.error(error.response);
+                        logError(error.response); //log http error via utility
 		} else {
 			// Network error: request never reached server or no response received
 			// Log just the error message as there's no response to examine
-			console.error(error.message);
+                        logError(error.message); //log network message via utility
 		}
 		
 		// Use qerrors for structured error logging with context
@@ -161,7 +162,7 @@ function handleAxiosError(error, contextMsg) {
                 // Error occurred within the error handler itself
                 // Attempt logging the secondary error and keep flow stable
                 try { qerrors(err, 'handleAxiosError error', {contextMsg}); } //log secondary error //(attempt qerrors)
-                catch (qe) { console.error(qe); } //fallback logging //(prevent crash)
+                catch (qe) { logError(qe); } //fallback logging via utility //(prevent crash)
                 if (DEBUG) { logReturn('handleAxiosError', false); } //log failure when debug
                 return false; // Indicate error handling failed
         }
@@ -263,10 +264,10 @@ async function getTopSearchResults(searchTerms) {
         // This defensive programming prevents API calls with invalid queries that would fail anyway
         const validSearchTerms = uniqueTerms.filter(term => typeof term === 'string' && term.trim() !== '');
 	
-	if (validSearchTerms.length === 0) {
-		console.warn('No valid search terms provided');
-		return []; // Return empty array rather than failing - graceful degradation
-	}
+        if (validSearchTerms.length === 0) {
+                logWarn('No valid search terms provided'); //use log utility for warnings
+                return []; // Return empty array rather than failing - graceful degradation
+        }
 	
         if (DEBUG) { logStart('getTopSearchResults', validSearchTerms); } //(log start when debug)
 	


### PR DESCRIPTION
## Summary
- add `minLogger` to control warn/error output via `LOG_LEVEL`
- use new logger in `qserp`
- document `LOG_LEVEL` env var
- test `minLogger`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6846921052748322a52dd362786a3c7c