### PR TITLE
Update debug logging to avoid heavy serialization

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -76,7 +76,8 @@ async function rateLimitedRequest(url) { //(handle network request with optional
         if (String(process.env.CODEX).toLowerCase() === 'true') { //(use case-insensitive true check for codex mock)
                 const mockRes = { data: { items: [] } }; //(define mock axios-like response)
                 if (DEBUG) { console.log('rateLimitedRequest using codex mock response'); } //(notify mock path taken when debug)
-                if (DEBUG) { logReturn('rateLimitedRequest', JSON.stringify(mockRes)); } //(mock return log when debug)
+                // Serializing entire mockRes would waste CPU during debugging
+                if (DEBUG) { logReturn('rateLimitedRequest', `mock items:${mockRes.data.items.length}`); } //(mock return log when debug)
                 return mockRes; //(return mocked response)
         }
 
@@ -203,7 +204,8 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                const cached = cache.get(query); //lookup existing cache entry
                if (cached) { //return if item is cached
                        if (DEBUG) { console.log('fetchSearchItems returning cached'); } //(log cache hit)
-                       logReturn('fetchSearchItems', JSON.stringify(cached)); //(log cached return)
+                       // Logging length avoids CPU cost of serializing full cache
+                       logReturn('fetchSearchItems', `cached items:${cached.length}`); //(log cached return)
                        return cached; //use cached array
                }
 
@@ -213,7 +215,8 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                 const response = await rateLimitedRequest(url); //(perform rate limited axios request)
                const items = response.data.items || []; //(extract items array if present)
                cache.set(query, items); //store results in LRU cache
-                if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log return value when debug)
+                // Avoid heavy serialization of the entire items array in logs
+                if (DEBUG) { logReturn('fetchSearchItems', `items:${items.length}`); } //(log return value when debug)
                 return items; //(return extracted items array)
         } catch (error) {
                 handleAxiosError(error, `Error in fetchSearchItems for query: ${query}`); //(handle and log any axios errors)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,9 +40,9 @@ const DEBUG = getDebugFlag(); //determine current debug state
  * @returns {any} Result of fn() if successful, defaultVal if fn() throws an error
  */
 function safeRun(fnName, fn, defaultVal, context) {
-	// Log the start of safe execution with context for debugging
-	// JSON.stringify handles the context object safely even if it contains complex data
-    if (DEBUG) { logStart('safeRun', JSON.stringify({ fnName, context })); } //log start when debug enabled
+        // Log the start of safe execution with context for debugging
+        // Serializing large objects can use significant CPU during debugging
+    if (DEBUG) { logStart('safeRun', `ctxKeys:${context ? Object.keys(context).length : 0}`); } //log start using context key count
 	
 	try {
 		// Execute the provided function


### PR DESCRIPTION
## Summary
- minimize debug output serialization in safeRun and qserp functions
- explain CPU cost when serializing large objects for logs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6846924239088322a0f7e638c58f27e4