### PR TITLE
Remove unused imports

### DIFF
--- a/advanced-security-test.js
+++ b/advanced-security-test.js
@@ -1,5 +1,3 @@
-const crypto = require('crypto');
-
 // Test environment setup
 process.env.CODEX = 'true';
 process.env.DEBUG = 'false';

--- a/cache-optimization-test.js
+++ b/cache-optimization-test.js
@@ -1,5 +1,3 @@
-const { performance } = require('perf_hooks');
-
 // Mock environment for testing
 process.env.CODEX = 'true';
 process.env.DEBUG = 'false';

--- a/memory-growth-analysis.js
+++ b/memory-growth-analysis.js
@@ -1,5 +1,3 @@
-const { performance } = require('perf_hooks');
-
 // Mock environment for testing
 process.env.CODEX = 'true';
 process.env.DEBUG = 'false';

--- a/rate-limit-real-test.js
+++ b/rate-limit-real-test.js
@@ -1,5 +1,3 @@
-const { performance } = require('perf_hooks');
-
 // Test with real bottleneck behavior (no CODEX mode)
 process.env.DEBUG = 'false';
 // Remove CODEX to test actual rate limiting

--- a/security-test.js
+++ b/security-test.js
@@ -1,5 +1,3 @@
-const { performance } = require('perf_hooks');
-
 // Mock environment for security testing
 process.env.CODEX = 'true';
 process.env.DEBUG = 'false';


### PR DESCRIPTION
## Summary
- remove unused `perf_hooks` import from performance tests
- clean up advanced security test by dropping unused `crypto` import

## Testing
- `npm test` *(fails: debugUtils.test.js errors)*

------
https://chatgpt.com/codex/tasks/task_b_6848d2b85ff0832295f4e8e89e153471