### PR TITLE
Update cache rationale note

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -8,7 +8,7 @@
  * 
  * ARCHITECTURE DECISIONS:
  * - Custom axios instance with connection pooling for sustained API usage
- * - Manual Map-based caching for test compatibility with mocked time
+ * - Migrated to LRU-cache for automatic eviction and TTL, improving memory management; manual Map caching removed
  * - Conservative rate limiting to prevent quota exhaustion in production
  * - Three-tier error handling: structured logging, minimal output, graceful degradation
  * 


### PR DESCRIPTION
## Summary
- update architecture note in lib/qserp.js to reflect move to lru-cache

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684923296d808322904646947ef0845d