### PR TITLE
Sanitize logged URL

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -64,13 +64,15 @@ test('handleAxiosError logs with qerrors and returns true', () => {
   expect(qerrorsMock).toHaveBeenCalled();
 });
 
-test('handleAxiosError logs response object and returns true', () => { //added new test for console.error
+test('handleAxiosError logs sanitized response object and returns true', () => { //updated test to verify sanitization
   const { handleAxiosError } = require('../lib/qserp'); //require function under test
-  const err = { response: { status: 500 } }; //mock error with response
+  const err = { response: { status: 500, config: { url: 'http://x?key=key' } } }; //mock error with key in url
   const spy = mockConsole('error'); //spy on console.error via helper
   const res = handleAxiosError(err, 'ctx'); //call function with response error
   expect(res).toBe(true); //should return true
-  expect(spy).toHaveBeenCalledWith(err.response); //console.error called with response
+  const logged = spy.mock.calls[0][0]; //capture logged object for inspection
+  expect(JSON.stringify(logged)).not.toContain('key=key'); //verify key removed from log
+  expect(logged.config.url).toBe('http://x?key=[redacted]'); //url should be sanitized
   spy.mockRestore(); //restore console.error
 });
 

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -214,8 +214,15 @@ function handleAxiosError(error, contextMsg) {
                         // HTTP error: Server responded but with error status (4xx, 5xx)
                         // RESPONSE AVAILABLE: Server was reachable, but rejected the request
                         // Common cases: 401 Unauthorized, 403 Forbidden, 429 Rate Limited, 500 Server Error
-                        // Log full response object containing status, headers, and error details
-                        logError(error.response);
+                        // Log full response object after sanitizing URL to protect API key
+                        const respCopy = { ...error.response }; //shallow copy of response for mutation
+                        if (respCopy.config && respCopy.config.url) { //if url present in config, sanitize
+                                respCopy.config = { //copy config to avoid mutating original
+                                        ...respCopy.config,
+                                        url: respCopy.config.url.replace(apiKey, '[redacted]') //hide API key from logs
+                                };
+                        }
+                        logError(respCopy); //log sanitized response object
                 } else if (error.request) {
                         // Network error: Request was made but no response received
                         // REQUEST TIMEOUT: DNS resolution failed, connection timeout, or server unreachable


### PR DESCRIPTION
## Summary
- sanitize URL logging in `handleAxiosError`
- verify sanitized log output in tests

## Testing
- `npm test` *(fails: debugUtils.test.js and others)*

------
https://chatgpt.com/codex/tasks/task_b_6849303ee8788322baab1a6b8abda80f