### PR TITLE
Clamp num argument in getGoogleURL

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -56,6 +56,17 @@ test('getGoogleURL builds proper url', () => {
   expect(urlNum).toBe('https://www.googleapis.com/customsearch/v1?q=hello&key=key&cx=cx&fields=items(title,snippet,link)&num=5'); //should include num param and fields filter
 });
 
+test.each([
+  [0, 1],
+  [11, 10],
+  [-3, 1],
+  [2.7, 3]
+])('getGoogleURL clamps num %p to %p', (val, expected) => {
+  const { getGoogleURL } = require('../lib/qserp');
+  const url = getGoogleURL('clamp', val);
+  expect(url).toBe(`https://www.googleapis.com/customsearch/v1?q=clamp&key=key&cx=cx&fields=items(title,snippet,link)&num=${expected}`);
+});
+
 test('handleAxiosError logs with qerrors and returns true', () => {
   const { handleAxiosError } = require('../lib/qserp');
   const err = new Error('fail');

--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -138,4 +138,13 @@ describe('qserp module', () => { //group qserp tests
     expect(second).toEqual([{ link: '2' }]); //expect second results not cached
     expect(scheduleMock).toHaveBeenCalled(); //new request should occur
   });
+
+  test('fetchSearchItems clamps out-of-range num', async () => { //new clamp test
+    mock.onGet(/Clamp/).reply(200, { items: [] }); //mock response
+    await fetchSearchItems('Clamp', 99); //use high invalid num
+    expect(mock.history.get[0].url).toBe('https://www.googleapis.com/customsearch/v1?q=Clamp&key=key&cx=cx&fields=items(title,snippet,link)&num=10'); //url should clamp num to 10
+    mock.onGet(/Clamp/).reply(200, { items: [] }); //mock again
+    await fetchSearchItems('Clamp', -5); //use low invalid num
+    expect(mock.history.get[1].url).toBe('https://www.googleapis.com/customsearch/v1?q=Clamp&key=key&cx=cx&fields=items(title,snippet,link)&num=1'); //url should clamp num to 1
+  });
 });

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -181,16 +181,20 @@ function getGoogleURL(query, num) { //accept optional num argument to limit resu
         // - Unicode characters are properly encoded for international search queries
         // - Prevents injection attacks through malformed URL construction
         const encodedQuery = encodeURIComponent(query);
-        
+
         // Construct base URL with required parameters and optimized field selection
         // FIELDS OPTIMIZATION: Only request title, snippet, link to reduce response payload
         // by ~50-70% compared to full response, improving network performance
         const base = `https://www.googleapis.com/customsearch/v1?q=${encodedQuery}&key=${apiKey}&cx=${cx}&fields=items(title,snippet,link)`;
-        
-        // Conditionally append result count parameter when specified
-        // TYPE CHECK: Ensures num is actually a number to prevent invalid API calls
-        // Google API expects integer values; invalid num params cause API errors
-        return typeof num === 'number' ? `${base}&num=${num}` : base;
+
+        // Validate and normalize num for API compliance; clamp invalid values
+        // RANGE ENFORCEMENT: Google API accepts integers 1-10 only, decimals are rounded
+        if (typeof num === 'number') { //ensure numeric input
+                let safeNum = Math.round(num); //convert to integer
+                safeNum = Math.min(10, Math.max(1, safeNum)); //clamp within 1-10 inclusive
+                return `${base}&num=${safeNum}`; //append sanitized num
+        }
+        return base; //return base url when num not provided
 }
 
 /**


### PR DESCRIPTION
## Summary
- validate result count passed to `getGoogleURL`
- cover new clamping behavior in internal function tests
- verify clamped values when fetching search items

## Testing
- `npx jest __tests__/internalFunctions.test.js __tests__/qserp.test.js --runInBand`
- `npm test` *(fails: debugUtils.test.js due to mockGetDebugFlag undefined)*

------
https://chatgpt.com/codex/tasks/task_b_6849304113dc83229d240d8c428b0dc7