### PR TITLE
Sanitize network error logs

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -76,6 +76,17 @@ test('handleAxiosError logs sanitized response object and returns true', () => {
   spy.mockRestore(); //restore console.error
 });
 
+test('handleAxiosError masks api key in network error logs', () => {
+  const { handleAxiosError } = require('../lib/qserp'); //load function under test
+  const err = { request: {}, message: 'bad key=key', config: { url: 'http://x?key=key' } }; //mock network error with key
+  const spy = mockConsole('error'); //spy on console.error
+  const res = handleAxiosError(err, 'ctx'); //call handler
+  expect(res).toBe(true); //should succeed
+  const logged = spy.mock.calls[0][0]; //grab logged string
+  expect(logged).not.toContain('key=key'); //ensure key removed
+  spy.mockRestore(); //cleanup spy
+});
+
 test('handleAxiosError returns false when qerrors throws', () => { //verify fallback on qerrors failure
   const { handleAxiosError } = require('../lib/qserp'); //load function under test
   const err = new Error('bad'); //mock basic error

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -78,6 +78,19 @@ const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
 const { logStart, logReturn } = require('./logUtils'); //standardized logging utilities
 const { logWarn, logError } = require('./minLogger'); //minimal log utility for warn/error
 
+// Utility to mask API key in log messages for security
+function sanitizeApiKey(text) {
+        console.log(`sanitizeApiKey is running with ${text}`); //trace start with input
+        try {
+                const result = typeof text === 'string' ? text.replace(apiKey, '[redacted]') : text; //replace key when string
+                console.log(`sanitizeApiKey is returning ${result}`); //trace sanitized result
+                return result; //return sanitized value
+        } catch (err) {
+                console.log(`sanitizeApiKey is returning ${text}`); //trace fallback path
+                return text; //return original on error
+        }
+}
+
 // Import utility functions for environment variable validation
 // These utilities centralize env var handling to avoid repetitive validation code
 const { throwIfMissingEnvVars, warnIfMissingEnvVars } = require('./envUtils'); //env validation utilities //(trim unused)
@@ -125,7 +138,7 @@ const limiter = new Bottleneck({
  * @private - Internal function not exposed in module exports
  */
 async function rateLimitedRequest(url) { //(handle network request with optional mock)
-        const safeUrl = url.replace(apiKey, '[redacted]'); //(sanitize api key from url)
+        const safeUrl = sanitizeApiKey(url); //(sanitize api key from url)
         if (DEBUG) { logStart('rateLimitedRequest', safeUrl); } //(avoid key leak with toggle)
 
         if (String(process.env.CODEX).toLowerCase() === 'true') { //(use case-insensitive true check for codex mock)
@@ -219,11 +232,11 @@ function handleAxiosError(error, contextMsg) {
                         // RESPONSE AVAILABLE: Server was reachable, but rejected the request
                         // Common cases: 401 Unauthorized, 403 Forbidden, 429 Rate Limited, 500 Server Error
                         // Log full response object after sanitizing URL to protect API key
-                        const respCopy = { ...error.response }; //shallow copy of response for mutation
+                        const respCopy = { ...error.response, message: sanitizeApiKey(error.message) }; //shallow copy with sanitized msg
                         if (respCopy.config && respCopy.config.url) { //if url present in config, sanitize
                                 respCopy.config = { //copy config to avoid mutating original
                                         ...respCopy.config,
-                                        url: respCopy.config.url.replace(apiKey, '[redacted]') //hide API key from logs
+                                        url: sanitizeApiKey(respCopy.config.url) //hide API key from logs
                                 };
                         }
                         logError(respCopy); //log sanitized response object
@@ -232,12 +245,16 @@ function handleAxiosError(error, contextMsg) {
                         // REQUEST TIMEOUT: DNS resolution failed, connection timeout, or server unreachable
                         // Common cases: Network connectivity issues, DNS problems, firewall blocking
                         // Log request details to help diagnose network issues
-                        logError(`Network error: ${error.message}`);
+                        const msg = sanitizeApiKey(error.message); //mask key from message
+                        const urlInfo = error.config && error.config.url ? ` url: ${sanitizeApiKey(error.config.url)}` : ''; //optional url
+                        logError(`Network error: ${msg}${urlInfo}`); //log sanitized text
                 } else {
                         // Configuration error: Error occurred before request was sent
                         // SETUP ERROR: Invalid URL, malformed request, or axios configuration issues
                         // This indicates problems in our code rather than external services
-                        logError(`Configuration error: ${error.message}`);
+                        const msg = sanitizeApiKey(error.message); //mask key from message
+                        const urlInfo = error.config && error.config.url ? ` url: ${sanitizeApiKey(error.config.url)}` : ''; //optional url
+                        logError(`Configuration error: ${msg}${urlInfo}`); //log sanitized message
                 }
                 
                 // Use qerrors for structured error logging with full context
@@ -321,11 +338,14 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                // Generate normalized cache key using centralized helper
                // CONSOLIDATION: Uses createCacheKey helper to ensure consistent normalization
                const cacheKey = createCacheKey(query, num); //use helper for consistent cache key generation
-               const cachedItems = cache.get(cacheKey); //lookup existing cache entry with automatic TTL handling
-               if (cachedItems) { //check if entry exists and hasn't expired
-                       if (DEBUG) { console.log('fetchSearchItems returning cached'); } //(log cache hit)
-                       logReturn('fetchSearchItems', JSON.stringify(cachedItems)); //(log cached return)
-                       return cachedItems; //use cached array
+               let cachedItems;
+               if (MAX_CACHE_SIZE !== 0) { //skip cache when disabled
+                       cachedItems = cache.get(cacheKey); //lookup existing cache entry with automatic TTL handling
+                       if (cachedItems) { //check if entry exists and hasn't expired
+                               if (DEBUG) { console.log('fetchSearchItems returning cached'); } //(log cache hit)
+                               logReturn('fetchSearchItems', JSON.stringify(cachedItems)); //(log cached return)
+                               return cachedItems; //use cached array
+                       }
                }
 
                 const url = getGoogleURL(query, num); //(build search url with optional num)
@@ -335,7 +355,7 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                
                // Store in LRU cache - TTL and size limits handled automatically
                // OPTIMIZATION: LRU-cache manages expiry and eviction without manual intervention
-               cache.set(cacheKey, items); //store results - TTL and size managed automatically
+               if (MAX_CACHE_SIZE !== 0) { cache.set(cacheKey, items); } //store results when cache enabled
                 if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log return value when debug)
                 return items; //(return extracted items array)
         } catch (error) {


### PR DESCRIPTION
## Summary
- centralize API key sanitization
- mask API key in network error logs
- disable cache logic when `QSERP_MAX_CACHE_SIZE` set to 0
- test that network errors log without exposing the key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bb53cc1288322bf2c96c1a19fa048