### PR TITLE
Adjust safeQerrors logging

### DIFF
--- a/__tests__/qerrorsLoader.test.js
+++ b/__tests__/qerrorsLoader.test.js
@@ -36,3 +36,32 @@ describe('loadQerrors', () => { //group loader tests
     });
   });
 });
+
+describe('safeQerrors', () => { //new tests for sanitized logging
+  test('logStart omits error message', () => {
+    jest.isolateModules(() => { //isolate module for mocking
+      const qerr = jest.fn(); //mock qerrors
+      jest.doMock('qerrors', () => qerr); //provide mock implementation
+      const { safeQerrors } = require('../lib/qerrorsLoader'); //load function
+      const { mockConsole } = require('./utils/consoleSpies'); //console spy helper
+      const spy = mockConsole('log'); //spy on console.log
+      safeQerrors(new Error('secret'), 'ctx'); //invoke with error
+      expect(spy).toHaveBeenCalledWith('safeQerrors is running with ctx'); //should log generic context only
+      spy.mockRestore(); //cleanup spy
+    });
+  });
+
+  test('fallback logs sanitized message', () => {
+    jest.isolateModules(() => { //isolate module for mocking
+      const qerr = jest.fn(() => { throw new Error('fail'); }); //mock throwing
+      jest.doMock('qerrors', () => qerr); //mock module
+      const { safeQerrors } = require('../lib/qerrorsLoader'); //load function
+      const { mockConsole } = require('./utils/consoleSpies'); //console helper
+      const spy = mockConsole('error'); //spy on console.error
+      safeQerrors(new Error('bad\nline'), 'ctx'); //invoke with newline
+      const joined = spy.mock.calls.map(c => c.join(' ')).join(' '); //aggregate output
+      expect(joined).not.toMatch(/\n/); //newline should be removed
+      spy.mockRestore(); //cleanup
+    });
+  });
+});

--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -75,13 +75,15 @@ function loadQerrors() {
  * @returns {boolean} - True if error was reported successfully, false if qerrors failed
  */
 function safeQerrors(error, context, additionalData = {}) {
-        logStart('safeQerrors', `${context}: ${error?.message || error}`);
+        logStart('safeQerrors', context); //avoid leaking raw error message
+
+        const safeMsg = String(error?.message || error).replace(/\n/g, ' '); //newline sanitize for later logs
         
         try {
                 const qerrors = loadQerrors();
                 
                 // Ensure error is an Error object for qerrors v1.2.3+ compatibility
-                const errorObj = error instanceof Error ? error : new Error(String(error));
+                const errorObj = error instanceof Error ? error : new Error(safeMsg); //use sanitized message when wrapping
                 
                 qerrors(errorObj, context, additionalData);
                 logReturn('safeQerrors', 'success');
@@ -89,14 +91,14 @@ function safeQerrors(error, context, additionalData = {}) {
         } catch (qerrorsError) {
                 // qerrors itself failed - fall back to basic logging
                 try {
-                        logError(`qerrors failed: ${qerrorsError.message}`);
-                        logError(`Original error: ${error?.message || error}`);
+                        logError(`qerrors failed: ${qerrorsError.message.replace(/\n/g,' ')}`); //sanitize nested message
+                        logError(`Original error: ${safeMsg}`); //log sanitized original message
                         logError(`Context: ${context}`);
                 } catch (logErr) {
                         // Even basic logging failed - use console as last resort
                         console.error('Critical: All error reporting systems failed');
-                        console.error('qerrors error:', qerrorsError.message);
-                        console.error('Original error:', error?.message || error);
+                        console.error('qerrors error:', qerrorsError.message.replace(/\n/g,' '));
+                        console.error('Original error:', safeMsg); //sanitized fallback output
                         console.error('Context:', context);
                 }
                 logReturn('safeQerrors', 'failed');

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -66,12 +66,14 @@ const MAX_CACHE_SIZE = Math.max(0, Math.min(rawMaxSize, 50000)); // Allow 0 to d
 // Initialize LRU cache with automatic memory management
 // OPTIMIZATION: LRU-cache handles eviction automatically, preventing memory leaks
 // and providing better performance than manual Map-based cleanup
-const cache = new LRUCache({
-        max: MAX_CACHE_SIZE === 0 ? 0 : MAX_CACHE_SIZE || 1000,  //explicit 0 disables cache
-        ttl: CACHE_TTL,               // Time-to-live in milliseconds
-        allowStale: false,            // Don't return stale items
-        updateAgeOnGet: true          // Refresh age when item is accessed (true LRU behavior)
-});
+const cache = MAX_CACHE_SIZE === 0 ? //create noop cache when disabled
+        { get: () => undefined, set: () => {} } : //noop methods keep API but skip storage
+        new LRUCache({
+                max: MAX_CACHE_SIZE || 1000,  //LRU max entries when enabled
+                ttl: CACHE_TTL,               // Time-to-live in milliseconds
+                allowStale: false,            // Don't return stale items
+                updateAgeOnGet: true          // Refresh age when item is accessed (true LRU behavior)
+        });
 
 // qerrors is used to handle error reporting and logging with structured context
 const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader


### PR DESCRIPTION
## Summary
- avoid leaking messages in `safeQerrors` startup log
- sanitize error strings before logging
- create noop cache when cache size set to `0`
- test `safeQerrors` sanitized behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684bb54accd483229c7c96f420e7fd5b