### PR TITLE
Handle noop cache cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,9 @@ process.env.QSERP_MAX_CACHE_SIZE = '100';  // Limit to 100 entries
 
 While LRU-cache evicts expired entries automatically, the library exposes
 `performCacheCleanup()` for diagnostic tests. Calling this function triggers
-`cache.purgeStale()` to remove any expired items.
+`cache.purgeStale()` to remove any expired items. When caching is disabled with
+`QSERP_MAX_CACHE_SIZE=0`, both `clearCache()` and `performCacheCleanup()` are
+safe no-ops that return without modifying state.
 
 ## Security Features
 

--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -169,4 +169,14 @@ describe('qserp module', () => { //group qserp tests
     expect(localSchedule).toHaveBeenCalled(); //schedule called again since no cache
     process.env.QSERP_MAX_CACHE_SIZE = savedSize; //restore environment
   });
+
+  test('cache helpers are no-ops when caching disabled', () => { //verify noop helpers
+    const savedSize = process.env.QSERP_MAX_CACHE_SIZE; //preserve env value
+    process.env.QSERP_MAX_CACHE_SIZE = '0'; //disable caching
+    jest.resetModules(); //reload module with noop cache
+    const { clearCache: clearLocal, performCacheCleanup } = require('../lib/qserp'); //require fresh module
+    expect(clearLocal()).toBe(true); //clearCache should succeed
+    expect(performCacheCleanup()).toBe(0); //no stale entries removed
+    process.env.QSERP_MAX_CACHE_SIZE = savedSize; //restore env value
+  });
 });

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -67,7 +67,7 @@ const MAX_CACHE_SIZE = Math.max(0, Math.min(rawMaxSize, 50000)); // Allow 0 to d
 // OPTIMIZATION: LRU-cache handles eviction automatically, preventing memory leaks
 // and providing better performance than manual Map-based cleanup
 const cache = MAX_CACHE_SIZE === 0 ? //create noop cache when disabled
-        { get: () => undefined, set: () => {} } : //noop methods keep API but skip storage
+        { get: () => undefined, set: () => {}, clear: () => {}, purgeStale: () => 0, size: 0 } : //noop methods keep API but skip storage and expose same interface
         new LRUCache({
                 max: MAX_CACHE_SIZE || 1000,  //LRU max entries when enabled
                 ttl: CACHE_TTL,               // Time-to-live in milliseconds


### PR DESCRIPTION
## Summary
- extend noop cache implementation
- clarify README about cache helper behavior
- test cache helpers with caching disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bc7d3f4408322b506829dd2ec9bff