### PR TITLE
Enable automatic TTL purging

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The module implements intelligent LRU caching with automatic memory management t
 - **TTL (Time To Live)**: 5 minutes (300,000ms) for all cached responses
 - **Cache Keys**: Normalized keys (case-insensitive, trimmed) improve hit ratios
 - **Memory Management**: Automatic LRU eviction with configurable size limits
-- **Built-in Cleanup**: LRU-cache handles expiry and memory management automatically
+ - **Built-in Cleanup**: `ttlAutopurge: true` removes expired entries automatically
 - **True LRU Behavior**: Recently accessed items refresh their age for optimal retention
 
 ### Cache Benefits
@@ -206,7 +206,7 @@ The module implements intelligent LRU caching with automatic memory management t
 - **Improved Performance**: Cached responses return instantly without network delay
 - **Memory Efficiency**: LRU eviction prevents memory leaks in long-running applications
 - **Quota Conservation**: Fewer API calls help stay within Google's daily limits
-- **Automatic Management**: No manual cleanup required, handles TTL and size limits internally
+ - **Automatic Management**: Automatic TTL purging means no manual cleanup is required
 
 ### Memory Management
 Configure cache behavior with the `QSERP_MAX_CACHE_SIZE` environment variable:
@@ -230,14 +230,14 @@ await fetchSearchItems('Node.js');         // New API call, cached separately
 
 // Memory management example
 process.env.QSERP_MAX_CACHE_SIZE = '100';  // Limit to 100 entries
-// LRU-cache automatically evicts least recently used entries when limit reached
+// LRU-cache automatically evicts least recently used entries and purges TTL expirations
 ```
 
 ### Manual Cache Cleanup
 
-While LRU-cache evicts expired entries automatically, the library exposes
+While expired entries are purged automatically, the library exposes
 `performCacheCleanup()` for diagnostic tests. Calling this function triggers
-`cache.purgeStale()` to remove any expired items.
+`cache.purgeStale()` to force immediate removal if needed.
 
 ## Security Features
 

--- a/__tests__/cacheInit.test.js
+++ b/__tests__/cacheInit.test.js
@@ -1,0 +1,16 @@
+const { setTestEnv } = require('./utils/testSetup');
+
+jest.mock('lru-cache', () => {
+  return { LRUCache: function(opts){ global.lruOpts = opts; return { get: () => undefined, set: () => {} }; } };
+});
+
+describe('cache initialization', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    setTestEnv();
+  });
+  test('uses ttlAutopurge option', () => {
+    require('../lib/qserp');
+    expect(global.lruOpts).toEqual(expect.objectContaining({ ttlAutopurge: true }));
+  });
+});

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -72,7 +72,8 @@ const cache = MAX_CACHE_SIZE === 0 ? //create noop cache when disabled
                 max: MAX_CACHE_SIZE || 1000,  //LRU max entries when enabled
                 ttl: CACHE_TTL,               // Time-to-live in milliseconds
                 allowStale: false,            // Don't return stale items
-                updateAgeOnGet: true          // Refresh age when item is accessed (true LRU behavior)
+                updateAgeOnGet: true,         // Refresh age when item is accessed (true LRU behavior)
+                ttlAutopurge: true            // Purge expired entries automatically for memory safety
         });
 
 // qerrors is used to handle error reporting and logging with structured context


### PR DESCRIPTION
## Summary
- enable `ttlAutopurge` option for the LRU cache
- clarify cache cleanup behavior in README
- test that the cache is created with `ttlAutopurge: true`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bc7d986b48322ab601f6fd696bea7