### PR TITLE
Fix sanitizeApiKey to replace all occurrences

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -72,7 +72,7 @@ test('handleAxiosError logs sanitized response object and returns true', () => {
   expect(res).toBe(true); //should return true
   const logged = spy.mock.calls[0][0]; //capture logged object for inspection
   expect(JSON.stringify(logged)).not.toContain('key=key'); //verify key removed from log
-  expect(logged.config.url).toBe('http://x?[redacted]=key'); //url should be sanitized
+  expect(logged.config.url).toBe('http://x?[redacted]=[redacted]'); //url should be fully sanitized
   spy.mockRestore(); //restore console.error
 });
 
@@ -118,4 +118,10 @@ test('validateSearchQuery accepts non-empty strings', () => { //(verify valid in
 test.each(['', '   ', 1, {}, []])('validateSearchQuery throws for %p', val => { //(verify invalid inputs)
   const { validateSearchQuery } = require('../lib/qserp'); //import helper
   expect(() => validateSearchQuery(val)).toThrow('Query must be a non-empty string'); //expect error thrown
+});
+
+test('sanitizeApiKey replaces all matches', () => { //ensure global replacement
+  const { sanitizeApiKey } = require('../lib/qserp'); //import function under test
+  const res = sanitizeApiKey('start key middle key end'); //call with repeated key
+  expect(res).toBe('start [redacted] middle [redacted] end'); //expect both replaced
 });

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -80,11 +80,13 @@ const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
 const { logStart, logReturn } = require('./logUtils'); //standardized logging utilities
 const { logWarn, logError } = require('./minLogger'); //minimal log utility for warn/error
 
+const keyRegex = apiKey ? new RegExp(apiKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //precompute global regex to match api key throughout
+
 // Utility to mask API key in log messages for security
 function sanitizeApiKey(text) {
         console.log(`sanitizeApiKey is running with ${text}`); //trace start with input
         try {
-                const result = typeof text === 'string' ? text.replace(apiKey, '[redacted]') : text; //replace key when string
+                const result = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //replace all occurrences using regex
                 console.log(`sanitizeApiKey is returning ${result}`); //trace sanitized result
                 return result; //return sanitized value
         } catch (err) {
@@ -526,6 +528,7 @@ module.exports = {
         handleAxiosError        // Centralized error handler
        , validateSearchQuery    // Validation helper for query strings //(export validation function)
        , createCacheKey         // Cache key generation helper for consistent normalization
+       , sanitizeApiKey         // Sanitization helper exported for testing
 
        , axiosInstance          // Expose configured axios instance for tests
 


### PR DESCRIPTION
## Summary
- use a global regular expression in `sanitizeApiKey` so every API key instance is redacted
- export `sanitizeApiKey` for testing
- update internal function tests for the new behavior
- add a new unit test verifying multiple replacements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bc7efa2148322afb0c3386b3442ca