### PR TITLE
Improve log serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ These variables enhance functionality but are not required:
 
 - `OPENAI_TOKEN` – Used by the `qerrors` dependency for enhanced error analysis and logging
 - `CODEX` – When set to any case-insensitive `true` value, enables offline mode with mocked responses
-- `LOG_LEVEL` – Controls `warn` and `error` output (`info` by default)
+- `LOG_LEVEL` – Controls `warn` and `error` output (`info` by default). Non-string messages are serialized to JSON
 - `QSERP_MAX_CACHE_SIZE` – Maximum cache entries (default: 1000, range: 10-50000) for memory management
 
 ## Usage

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -70,8 +70,9 @@ test('handleAxiosError logs sanitized response object and returns true', () => {
   const spy = mockConsole('error'); //spy on console.error via helper
   const res = handleAxiosError(err, 'ctx'); //call function with response error
   expect(res).toBe(true); //should return true
-  const logged = spy.mock.calls[0][0]; //capture logged object for inspection
-  expect(JSON.stringify(logged)).not.toContain('key=key'); //verify key removed from log
+  const loggedStr = spy.mock.calls[0][0]; //capture logged string for inspection
+  const logged = JSON.parse(loggedStr); //parse back to object for assertions
+  expect(loggedStr).not.toContain('key=key'); //verify key removed from log string
   expect(logged.config.url).toBe('http://x?[redacted]=key'); //url should be sanitized
   spy.mockRestore(); //restore console.error
 });

--- a/__tests__/minLogger.test.js
+++ b/__tests__/minLogger.test.js
@@ -32,4 +32,24 @@ describe('minLogger', () => {
     expect(spy).toHaveBeenCalledWith('bad'); //should log
     spy.mockRestore(); //cleanup
   });
+
+  test('logWarn serializes object messages', () => { //object warn logging
+    process.env.LOG_LEVEL = 'warn'; //set level
+    const spy = mockConsole('warn'); //spy on console.warn
+    const { logWarn } = require('../lib/minLogger'); //import function
+    const obj = { a: 1 }; //sample object
+    logWarn(obj); //call logger with object
+    expect(spy).toHaveBeenCalledWith(JSON.stringify(obj)); //should log JSON
+    spy.mockRestore(); //cleanup
+  });
+
+  test('logError serializes object messages', () => { //object error logging
+    process.env.LOG_LEVEL = 'error'; //set level
+    const spy = mockConsole('error'); //spy on console.error
+    const { logError } = require('../lib/minLogger'); //import function
+    const obj = { b: 2 }; //sample object
+    logError(obj); //call logger with object
+    expect(spy).toHaveBeenCalledWith(JSON.stringify(obj)); //should log JSON
+    spy.mockRestore(); //cleanup
+  });
 });

--- a/lib/minLogger.js
+++ b/lib/minLogger.js
@@ -24,6 +24,24 @@
 // environments than warning messages, following standard logging practices
 const levelRank = { error: 0, warn: 1, info: 2, silent: 3 }; //rank map for levels
 
+// Safely converts any message into a string for logging
+// Converts objects via JSON.stringify with fallback on error
+function safeSerialize(msg) {
+        console.log(`safeSerialize is running with ${msg}`); //trace serialization start
+        try {
+                if (typeof msg === 'string') { //no conversion needed for strings
+                        console.log(`safeSerialize is returning ${msg}`); //trace string return
+                        return msg; //use as-is
+                }
+                const serialized = JSON.stringify(msg); //serialize object to JSON
+                console.log(`safeSerialize is returning ${serialized}`); //trace object return
+                return serialized; //return JSON text
+        } catch (err) {
+                console.log(`safeSerialize returning <unserializable value>`); //trace failure path
+                return '<unserializable value>'; //safe fallback
+        }
+}
+
 /**
  * Determines if a message at the given level should be logged
  * 
@@ -92,7 +110,8 @@ function logWarn(msg) {
                 // Check if warning level is allowed by current LOG_LEVEL setting
                 // This delegation ensures consistent level handling across all log functions
                 if (shouldLog('warn')) { //respect LOG_LEVEL for warnings
-                        console.warn(msg); //emit warning when allowed
+                        const output = safeSerialize(msg); //prepare message string
+                        console.warn(output); //emit warning when allowed
                 }
                 console.log(`logWarn is returning true`); //trace successful end
                 return true; //confirm execution
@@ -125,7 +144,8 @@ function logError(msg) {
                 // Check if error level is allowed (should be true unless LOG_LEVEL='silent')
                 // This maintains consistency with the level checking pattern
                 if (shouldLog('error')) { //respect LOG_LEVEL for errors
-                        console.error(msg); //emit error when allowed
+                        const output = safeSerialize(msg); //prepare message string
+                        console.error(output); //emit error when allowed
                 }
                 console.log(`logError is returning true`); //trace successful end
                 return true; //confirm execution


### PR DESCRIPTION
## Summary
- serialize object logs in `minLogger`
- add README note about JSON log behavior
- test object logging
- update internal test expectations

## Testing
- `npx jest __tests__/minLogger.test.js --runInBand`
- `npx jest __tests__/internalFunctions.test.js --runInBand`
- `npx jest --runInBand --json --outputFile=/tmp/result.json --silent` *(fails: format.timestamp is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_684bc7f63470832283d4d5c823357e65