### PR TITLE
HandleAxiosError sanitizes copy

### DIFF
--- a/__tests__/indexExport.test.js
+++ b/__tests__/indexExport.test.js
@@ -1,3 +1,4 @@
+jest.mock('qerrors', () => jest.fn()); //prevent real qerrors side effects
 process.env.GOOGLE_API_KEY = 'key'; //set required api key for module load
 process.env.GOOGLE_CX = 'cx'; //set required cx id for module load
 const indexExports = require('../index'); //(import index module to test re-export)

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -87,6 +87,17 @@ test('handleAxiosError masks api key in network error logs', () => {
   spy.mockRestore(); //cleanup spy
 });
 
+test('handleAxiosError passes sanitized error to qerrors', () => { //verify qerrors arg
+  const { handleAxiosError } = require('../lib/qserp'); //load function
+  const err = new Error('bad key=key'); //create error with key in message
+  err.config = { url: 'http://x?key=key' }; //attach url containing key
+  handleAxiosError(err, 'ctx'); //invoke handler
+  const arg = qerrorsMock.mock.calls[0][0]; //extract error passed to qerrors
+  expect(arg).not.toBe(err); //should be copied
+  expect(arg.message).toBe('bad [redacted]=[redacted]'); //message sanitized
+  expect(arg.config.url).toBe('http://x?[redacted]=[redacted]'); //url sanitized
+});
+
 test('handleAxiosError returns false when qerrors throws', () => { //verify fallback on qerrors failure
   const { handleAxiosError } = require('../lib/qserp'); //load function under test
   const err = new Error('bad'); //mock basic error

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -80,13 +80,15 @@ const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
 const { logStart, logReturn } = require('./logUtils'); //standardized logging utilities
 const { logWarn, logError } = require('./minLogger'); //minimal log utility for warn/error
 
-const keyRegex = apiKey ? new RegExp(apiKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //precompute global regex to match api key throughout
+const keyRegex = apiKey ? new RegExp(apiKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //precompute regex for raw api key
+const encKeyRegex = apiKey ? new RegExp(encodeURIComponent(apiKey).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi') : null; //regex for percent encoded key
 
 // Utility to mask API key in log messages for security
-function sanitizeApiKey(text) {
+function sanitizeApiKey(text) { //replace raw or encoded api key in text
         console.log(`sanitizeApiKey is running with ${text}`); //trace start with input
         try {
-                const result = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //replace all occurrences using regex
+                let result = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //remove raw key
+                result = typeof result === 'string' && encKeyRegex ? result.replace(encKeyRegex, '[redacted]') : result; //remove encoded key
                 console.log(`sanitizeApiKey is returning ${result}`); //trace sanitized result
                 return result; //return sanitized value
         } catch (err) {
@@ -227,44 +229,38 @@ function getGoogleURL(query, num) { //accept optional num argument to limit resu
  */
 function handleAxiosError(error, contextMsg) {
         if (DEBUG) { logStart('handleAxiosError', contextMsg); } //debug log gated by DEBUG
-        
+
         try {
+                const sanitized = Object.assign(new Error(), error); //clone properties into new Error object
+                sanitized.message = sanitizeApiKey(error.message); //overwrite message with sanitized value
+                if (error.config && error.config.url) { //preserve other config props
+                        sanitized.config = { ...error.config, url: sanitizeApiKey(error.config.url) }; //sanitize url field
+                }
+
                 // Differentiate between HTTP errors and network errors for appropriate handling
                 // ERROR CLASSIFICATION STRATEGY: Axios provides different error structures based on failure type
                 if (error.response) {
                         // HTTP error: Server responded but with error status (4xx, 5xx)
                         // RESPONSE AVAILABLE: Server was reachable, but rejected the request
-                        // Common cases: 401 Unauthorized, 403 Forbidden, 429 Rate Limited, 500 Server Error
                         // Log full response object after sanitizing URL to protect API key
-                        const respCopy = { ...error.response, message: sanitizeApiKey(error.message) }; //shallow copy with sanitized msg
-                        if (respCopy.config && respCopy.config.url) { //if url present in config, sanitize
-                                respCopy.config = { //copy config to avoid mutating original
-                                        ...respCopy.config,
-                                        url: sanitizeApiKey(respCopy.config.url) //hide API key from logs
-                                };
+                        const respCopy = { ...error.response, message: sanitized.message }; //copy response with sanitized msg
+                        if (respCopy.config && respCopy.config.url) {
+                                respCopy.config = { ...respCopy.config, url: sanitizeApiKey(respCopy.config.url) }; //sanitize url in response config
                         }
                         logError(respCopy); //log sanitized response object
                 } else if (error.request) {
                         // Network error: Request was made but no response received
-                        // REQUEST TIMEOUT: DNS resolution failed, connection timeout, or server unreachable
-                        // Common cases: Network connectivity issues, DNS problems, firewall blocking
-                        // Log request details to help diagnose network issues
-                        const msg = sanitizeApiKey(error.message); //mask key from message
-                        const urlInfo = error.config && error.config.url ? ` url: ${sanitizeApiKey(error.config.url)}` : ''; //optional url
-                        logError(`Network error: ${msg}${urlInfo}`); //log sanitized text
+                        const urlInfo = sanitized.config && sanitized.config.url ? ` url: ${sanitized.config.url}` : ''; //optional sanitized url
+                        logError(`Network error: ${sanitized.message}${urlInfo}`); //log sanitized text
                 } else {
                         // Configuration error: Error occurred before request was sent
-                        // SETUP ERROR: Invalid URL, malformed request, or axios configuration issues
-                        // This indicates problems in our code rather than external services
-                        const msg = sanitizeApiKey(error.message); //mask key from message
-                        const urlInfo = error.config && error.config.url ? ` url: ${sanitizeApiKey(error.config.url)}` : ''; //optional url
-                        logError(`Configuration error: ${msg}${urlInfo}`); //log sanitized message
+                        const urlInfo = sanitized.config && sanitized.config.url ? ` url: ${sanitized.config.url}` : ''; //optional sanitized url
+                        logError(`Configuration error: ${sanitized.message}${urlInfo}`); //log sanitized message
                 }
-                
-                // Use qerrors for structured error logging with full context
-                // STRUCTURED REPORTING: Enables error aggregation, monitoring, and analysis
-                // CONTEXT FIX: Pass contextMsg directly instead of wrapping in redundant object
-                qerrors(error, contextMsg, { operation: contextMsg, errorType: error.name });
+
+                // Use qerrors for structured error logging with sanitized copy
+                // STRUCTURED REPORTING: Enables error aggregation, monitoring, and analysis without leaking secrets
+                qerrors(sanitized, contextMsg, { operation: contextMsg, errorType: sanitized.name });
                 
                 if (DEBUG) { logReturn('handleAxiosError', true); } //log return when debug
                 return true; // Indicate error was handled successfully


### PR DESCRIPTION
## Summary
- sanitize both raw and encoded API keys
- pass sanitized error object to qerrors
- ensure qerrors is mocked in index exports test
- cover sanitized qerrors object in unit tests

## Testing
- `npx jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_b_684bd74bed5c8322bf0fb9af3acc4012