### PR TITLE
Encode API key and CX in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Before using the module, set these required environment variables:
 
 - `GOOGLE_API_KEY` – Your Google API key. Obtain from the [Google Cloud Console](https://console.cloud.google.com/)
 - `GOOGLE_CX` – Your Custom Search Engine ID. Set up at [Google Programmable Search Engine](https://programmablesearchengine.google.com/)
+Both values are URL encoded internally so keys containing characters like `+` or `/` work without additional configuration.
 
 ### Optional Variables
 These variables enhance functionality but are not required:

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -56,6 +56,15 @@ test('getGoogleURL builds proper url', () => {
   expect(urlNum).toBe('https://www.googleapis.com/customsearch/v1?q=hello&key=key&cx=cx&fields=items(title,snippet,link)&num=5'); //should include num param and fields filter
 });
 
+test('getGoogleURL encodes key and cx values', () => {
+  process.env.GOOGLE_API_KEY = 'k+/val'; //set api key with special chars
+  process.env.GOOGLE_CX = 'cx/+'; //set cx with special chars
+  jest.resetModules(); //reload module with new env vars
+  const { getGoogleURL } = require('../lib/qserp');
+  const url = getGoogleURL('encode');
+  expect(url).toBe('https://www.googleapis.com/customsearch/v1?q=encode&key=k%2B%2Fval&cx=cx%2F%2B&fields=items(title,snippet,link)'); //encoded key and cx
+});
+
 test('handleAxiosError logs with qerrors and returns true', () => {
   const { handleAxiosError } = require('../lib/qserp');
   const err = new Error('fail');

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -202,7 +202,9 @@ function getGoogleURL(query, num) { //accept optional num argument to limit resu
         // Construct base URL with required parameters and optimized field selection
         // FIELDS OPTIMIZATION: Only request title, snippet, link to reduce response payload
         // by ~50-70% compared to full response, improving network performance
-        const base = `https://www.googleapis.com/customsearch/v1?q=${encodedQuery}&key=${apiKey}&cx=${cx}&fields=items(title,snippet,link)`; //build base url
+        const encodedKey = encodeURIComponent(apiKey); //url encode api key to handle special chars
+        const encodedCx = encodeURIComponent(cx); //url encode cx id to handle special chars
+        const base = `https://www.googleapis.com/customsearch/v1?q=${encodedQuery}&key=${encodedKey}&cx=${encodedCx}&fields=items(title,snippet,link)`; //build base url with encoded creds
 
         // Validate optional num parameter to stay within Google API bounds 1-10
         // VALIDATION RATIONALE: Google rejects values outside range; clamp avoids errors


### PR DESCRIPTION
## Summary
- encode API key and Custom Search Engine ID in `getGoogleURL`
- document that key and CX values are encoded
- test encoding behaviour for API key and CX containing `+` and `/`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bd78b06688322b592ad1f1ed309b5