### PR TITLE
Handle CODEX mode in getGoogleURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ When the environment variable `CODEX` is set to any case-insensitive `true` valu
 - **Mock responses** are returned from all search functions
 - **Environment validation** is bypassed for API credentials
 - **Full functionality** is preserved for testing and development
+- **getGoogleURL** returns a placeholder URL `offline://mock-search` in this mode
 
 Example:
 

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -56,6 +56,15 @@ test('getGoogleURL builds proper url', () => {
   expect(urlNum).toBe('https://www.googleapis.com/customsearch/v1?q=hello&key=key&cx=cx&fields=items(title,snippet,link)&num=5'); //should include num param and fields filter
 });
 
+test('getGoogleURL returns placeholder when CODEX true', () => {
+  process.env.CODEX = 'true'; //enable offline mode
+  ({ mock, scheduleMock, qerrorsMock } = initSearchTest()); //reinit with codex flag
+  const { getGoogleURL } = require('../lib/qserp'); //import after codex enabled
+  const url = getGoogleURL('x'); //call function expecting placeholder
+  expect(url).toBe('offline://mock-search'); //should match placeholder value
+  delete process.env.CODEX; //cleanup codex flag
+});
+
 test('handleAxiosError logs with qerrors and returns true', () => {
   const { handleAxiosError } = require('../lib/qserp');
   const err = new Error('fail');

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -191,6 +191,13 @@ warnIfMissingEnvVars(OPTIONAL_VARS, OPENAI_WARN_MSG); //use centralized warning 
  * @private - Internal function used by public search functions
  */
 function getGoogleURL(query, num) { //accept optional num argument to limit results
+        if (DEBUG) { logStart('getGoogleURL', `${query}, num: ${num}`); } //trace inputs when debug
+
+        if (String(process.env.CODEX).toLowerCase() === 'true') { //return placeholder in offline mode
+                if (DEBUG) { logReturn('getGoogleURL', 'offline://mock-search'); } //trace placeholder return
+                return 'offline://mock-search'; //explicit offline placeholder URL
+        }
+
         // Apply proper URL encoding for query parameter safety and correctness
         // ENCODING RATIONALE: encodeURIComponent handles critical character transformations:
         // - Spaces become %20 (not + which has different semantics in query strings)
@@ -209,8 +216,11 @@ function getGoogleURL(query, num) { //accept optional num argument to limit resu
         let safeNum = Number.isFinite(num) ? Math.floor(num) : null; //ensure finite integer
         if (safeNum !== null) { //only adjust if provided
                 safeNum = Math.min(Math.max(safeNum, 1), 10); //clamp between 1 and 10
-                return `${base}&num=${safeNum}`; //append validated num parameter
+                const url = `${base}&num=${safeNum}`; //append validated num parameter
+                if (DEBUG) { logReturn('getGoogleURL', url); } //trace return when debug
+                return url; //return complete url
         }
+        if (DEBUG) { logReturn('getGoogleURL', base); } //trace base return
         return base; //omit num when not provided
 }
 


### PR DESCRIPTION
## Summary
- handle offline CODEX mode inside `getGoogleURL`
- note placeholder URL in README
- expect placeholder in new internal function test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bd7a534c08322a6cf02e17836c71b