### PR TITLE
Handle encoded API key in sanitizer

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -1,4 +1,4 @@
-const { initSearchTest, resetMocks } = require('./utils/testSetup'); //import helpers for env and mocks
+const { initSearchTest, resetMocks, saveEnv, restoreEnv } = require('./utils/testSetup'); //import helpers for env and mocks
 const { mockConsole } = require('./utils/consoleSpies'); //added console spy helper
 
 let mock; //axios mock reference
@@ -124,4 +124,14 @@ test('sanitizeApiKey replaces all matches', () => { //ensure global replacement
   const { sanitizeApiKey } = require('../lib/qserp'); //import function under test
   const res = sanitizeApiKey('start key middle key end'); //call with repeated key
   expect(res).toBe('start [redacted] middle [redacted] end'); //expect both replaced
+});
+
+test('sanitizeApiKey replaces encoded matches', () => { //verify url-encoded key removal
+  const env = saveEnv(); //store current env
+  process.env.GOOGLE_API_KEY = 'k y'; //set key with space for encoding
+  jest.resetModules(); //reload module for new regex
+  const { sanitizeApiKey } = require('../lib/qserp'); //load with updated key
+  const res = sanitizeApiKey('first k%20y second'); //string contains encoded key
+  expect(res).toBe('first [redacted] second'); //should redact encoded key
+  restoreEnv(env); //restore env for other tests
 });

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -81,12 +81,15 @@ const { logStart, logReturn } = require('./logUtils'); //standardized logging ut
 const { logWarn, logError } = require('./minLogger'); //minimal log utility for warn/error
 
 const keyRegex = apiKey ? new RegExp(apiKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //precompute global regex to match api key throughout
+const encodedKeyRegex = apiKey ? new RegExp(encodeURIComponent(apiKey).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //regex for encoded api key to catch url-encoded leaks
 
 // Utility to mask API key in log messages for security
 function sanitizeApiKey(text) {
         console.log(`sanitizeApiKey is running with ${text}`); //trace start with input
         try {
-                const result = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //replace all occurrences using regex
+                const result = typeof text === 'string' && keyRegex
+                        ? text.replace(keyRegex, '[redacted]').replace(encodedKeyRegex, '[redacted]') //replace plain and encoded key
+                        : text; //return original when no regex
                 console.log(`sanitizeApiKey is returning ${result}`); //trace sanitized result
                 return result; //return sanitized value
         } catch (err) {


### PR DESCRIPTION
## Summary
- sanitize encoded API key values in `sanitizeApiKey`
- check encoded keys are removed in internal function tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bd7baec1883229dbfbd1ed08f8a9c