### PR TITLE
Fix sanitized logging on DEBUG

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -85,16 +85,16 @@ const encKeyRegex = apiKey ? new RegExp(encodeURIComponent(apiKey).replace(/[.*+
 
 // Utility to mask API key in log messages for security
 function sanitizeApiKey(text) { //replace raw or encoded api key in text
-        console.log(`sanitizeApiKey is running with ${text}`); //trace start with input
+        let result; //final sanitized value holder
         try {
-                let result = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //remove raw key
+                result = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //remove raw key
                 result = typeof result === 'string' && encKeyRegex ? result.replace(encKeyRegex, '[redacted]') : result; //remove encoded key
-                console.log(`sanitizeApiKey is returning ${result}`); //trace sanitized result
-                return result; //return sanitized value
         } catch (err) {
-                console.log(`sanitizeApiKey is returning ${text}`); //trace fallback path
-                return text; //return original on error
+                result = text; //fallback to original when error occurs
         }
+        if (DEBUG) { console.log(`sanitizeApiKey is running with ${result}`); } //log sanitized input when debug
+        if (DEBUG) { console.log(`sanitizeApiKey is returning ${result}`); } //log sanitized output when debug
+        return result; //return sanitized value
 }
 
 // Import utility functions for environment variable validation


### PR DESCRIPTION
## Summary
- sanitize API key logs only when DEBUG enabled
- add tests verifying sanitized logging behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684cf6b9ec348322af26c7e2a6fd1f33