### PR TITLE
Add normalized num helper and tests

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -192,6 +192,19 @@ warnIfMissingEnvVars(OPTIONAL_VARS, OPENAI_WARN_MSG); //use centralized warning 
  * @throws {Error} If query contains characters that cannot be URL encoded
  * @private - Internal function used by public search functions
  */
+function normalizeNum(num) { //return clamped integer or null for invalid input
+       console.log(`normalizeNum is running with ${num}`); //trace start for debug
+       try {
+               let safe = Number.isFinite(num) ? Math.floor(num) : null; //ensure finite integer for clamping
+               if (safe !== null) { safe = Math.min(Math.max(safe, 1), 10); } //clamp between 1 and 10 when provided
+               console.log(`normalizeNum is returning ${safe}`); //trace resulting value
+               return safe; //propagate normalized number or null
+       } catch (err) {
+               console.log('normalizeNum is returning null'); //trace fallback on error
+               return null; //return null if normalization fails
+       }
+}
+
 function getGoogleURL(query, num) { //accept optional num argument to limit results
         // Apply proper URL encoding for query parameter safety and correctness
         // ENCODING RATIONALE: encodeURIComponent handles critical character transformations:
@@ -208,13 +221,10 @@ function getGoogleURL(query, num) { //accept optional num argument to limit resu
         const encodedCx = encodeURIComponent(cx); //url encode cx id to handle special chars
         const base = `https://www.googleapis.com/customsearch/v1?q=${encodedQuery}&key=${encodedKey}&cx=${encodedCx}&fields=items(title,snippet,link)`; //build base url with encoded creds
 
-        // Validate optional num parameter to stay within Google API bounds 1-10
-        // VALIDATION RATIONALE: Google rejects values outside range; clamp avoids errors
-        let safeNum = Number.isFinite(num) ? Math.floor(num) : null; //ensure finite integer
-        if (safeNum !== null) { //only adjust if provided
-                safeNum = Math.min(Math.max(safeNum, 1), 10); //clamp between 1 and 10
-                return `${base}&num=${safeNum}`; //append validated num parameter
-        }
+        // Normalize num parameter to Google's allowed range 1-10
+        // REUSE LOGIC: Delegates clamping to normalizeNum for consistency
+        const safeNum = normalizeNum(num); //clamp or null via helper
+        if (safeNum !== null) { return `${base}&num=${safeNum}`; } //append when provided
         return base; //omit num when not provided
 }
 
@@ -312,11 +322,12 @@ function validateSearchQuery(query) {
  */
 function createCacheKey(query, num) {
         if (DEBUG) { logStart('createCacheKey', `${query}, num: ${num}`); }
-        
+
         // Normalize query for better cache hit ratios
         // Case-insensitive and whitespace-trimmed keys improve efficiency
         const normalizedQuery = query.trim().toLowerCase();
-        const cacheKey = num ? `${normalizedQuery}:${num}` : normalizedQuery;
+        const safeNum = normalizeNum(num); //ensure num consistent with URL helper
+        const cacheKey = safeNum ? `${normalizedQuery}:${safeNum}` : normalizedQuery; //use clamped value in key
         
         if (DEBUG) { logReturn('createCacheKey', cacheKey); }
         return cacheKey;
@@ -337,9 +348,12 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
         validateSearchQuery(query); //(reuse validation helper)
         try {
 
+               // Normalize num once to share between cache key and URL
+               const safeNum = normalizeNum(num); //clamp value for consistent behavior
+
                // Generate normalized cache key using centralized helper
                // CONSOLIDATION: Uses createCacheKey helper to ensure consistent normalization
-               const cacheKey = createCacheKey(query, num); //use helper for consistent cache key generation
+               const cacheKey = createCacheKey(query, safeNum); //use helper with clamped value
                let cachedItems;
                if (MAX_CACHE_SIZE !== 0) { //skip cache when disabled
                        cachedItems = cache.get(cacheKey); //lookup existing cache entry with automatic TTL handling
@@ -350,7 +364,7 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                        }
                }
 
-                const url = getGoogleURL(query, num); //(build search url with optional num)
+               const url = getGoogleURL(query, safeNum); //(build search url with clamped num)
 
                 const response = await rateLimitedRequest(url); //(perform rate limited axios request)
                const items = response.data.items || []; //(extract items array if present)
@@ -523,10 +537,11 @@ module.exports = {
         // Internal functions exported for testing
         rateLimitedRequest,     // HTTP request wrapper with rate limiting
         getGoogleURL,           // URL builder for Google API
-        handleAxiosError        // Centralized error handler
+       handleAxiosError        // Centralized error handler
        , validateSearchQuery    // Validation helper for query strings //(export validation function)
        , createCacheKey         // Cache key generation helper for consistent normalization
        , sanitizeApiKey         // Sanitization helper exported for testing
+       , normalizeNum           // Number normalization helper exported for reuse
 
        , axiosInstance          // Expose configured axios instance for tests
 


### PR DESCRIPTION
## Summary
- add `normalizeNum` helper for shared clamping logic
- use this helper in `getGoogleURL`, `createCacheKey` and `fetchSearchItems`
- export helper for testing
- test that invalid `num` values share cache with clamped values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684cf6c23dd88322a913a684d0c4130a