### PR TITLE
Fix sanitizeApiKey logging

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -145,3 +145,17 @@ test('sanitizeApiKey replaces all matches', () => { //ensure global replacement
   const res = sanitizeApiKey('start key middle key end'); //call with repeated key
   expect(res).toBe('start [redacted] middle [redacted] end'); //expect both replaced
 });
+
+test('sanitizeApiKey does not log raw key with DEBUG on', () => { //verify log sanitization
+  const spy = mockConsole('log'); //capture console.log output
+  jest.isolateModules(() => { //load module with custom env
+    process.env.DEBUG = 'true'; //enable debug output
+    process.env.GOOGLE_API_KEY = 'secret123'; //unique key for detection
+    process.env.GOOGLE_CX = 'cx'; //required env var
+    const { sanitizeApiKey } = require('../lib/qserp'); //load fresh module
+    sanitizeApiKey('use secret123 here'); //invoke with raw key
+  });
+  const logged = spy.mock.calls.map(c => c.join(' ')).join(' '); //combine log messages
+  expect(logged).not.toContain('secret123'); //ensure raw key never logged
+  spy.mockRestore(); //cleanup spy
+});

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -85,16 +85,16 @@ const encKeyRegex = apiKey ? new RegExp(encodeURIComponent(apiKey).replace(/[.*+
 
 // Utility to mask API key in log messages for security
 function sanitizeApiKey(text) { //replace raw or encoded api key in text
-        console.log(`sanitizeApiKey is running with ${text}`); //trace start with input
+        let result; //hold sanitized string before logging
         try {
-                let result = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //remove raw key
+                result = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //remove raw key first
                 result = typeof result === 'string' && encKeyRegex ? result.replace(encKeyRegex, '[redacted]') : result; //remove encoded key
-                console.log(`sanitizeApiKey is returning ${result}`); //trace sanitized result
-                return result; //return sanitized value
         } catch (err) {
-                console.log(`sanitizeApiKey is returning ${text}`); //trace fallback path
-                return text; //return original on error
+                result = text; //fallback to original when replacement fails
         }
+        console.log(`sanitizeApiKey is running with ${result}`); //log sanitized input after computation
+        console.log(`sanitizeApiKey is returning ${result}`); //log same sanitized value before returning
+        return result; //return sanitized text to caller
 }
 
 // Import utility functions for environment variable validation


### PR DESCRIPTION
## Summary
- sanitize strings before logging in `sanitizeApiKey`
- log sanitized string at function entry and exit
- verify no API key leaks when DEBUG is enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684cf6d0aca88322a5c94dbbd4f2a974