### PR TITLE
Fix cache size parsing radix

### DIFF
--- a/__tests__/cacheSizeParsing.test.js
+++ b/__tests__/cacheSizeParsing.test.js
@@ -1,0 +1,31 @@
+const { saveEnv, restoreEnv, setTestEnv } = require('./utils/testSetup');
+
+let savedEnv;
+
+beforeEach(() => {
+  savedEnv = saveEnv();
+  jest.resetModules();
+});
+
+afterEach(() => {
+  restoreEnv(savedEnv);
+  jest.resetModules();
+});
+
+test('parses QSERP_MAX_CACHE_SIZE with leading zero as decimal', () => {
+  setTestEnv();
+  process.env.QSERP_MAX_CACHE_SIZE = '08';
+
+  const LRUCacheMock = jest.fn().mockImplementation(() => ({
+    get: jest.fn(),
+    set: jest.fn(),
+    clear: jest.fn(),
+    purgeStale: jest.fn(() => 0),
+    size: 0
+  }));
+  jest.doMock('lru-cache', () => ({ LRUCache: LRUCacheMock }));
+
+  require('../lib/qserp');
+
+  expect(LRUCacheMock).toHaveBeenCalledWith(expect.objectContaining({ max: 8 }));
+});

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -59,7 +59,7 @@ const CACHE_TTL = 300000; //5 minute cache lifespan in ms
 // These constants provide configurable limits to prevent unbounded growth.
 // SECURITY ENHANCEMENT: Validate environment values to prevent malicious configuration
 // ZERO VALUE FIX: Use isNaN check to allow cache size of 0 (disables caching)
-const envCacheSize = parseInt(process.env.QSERP_MAX_CACHE_SIZE);
+const envCacheSize = parseInt(process.env.QSERP_MAX_CACHE_SIZE, 10); //parse decimal to avoid octal interpretation
 const rawMaxSize = !isNaN(envCacheSize) ? envCacheSize : 1000;
 const MAX_CACHE_SIZE = Math.max(0, Math.min(rawMaxSize, 50000)); // Allow 0 to disable caching
 


### PR DESCRIPTION
## Summary
- parse env var with radix to avoid octal parsing
- test cache size parsing when QSERP_MAX_CACHE_SIZE has leading zero

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684cf6d39c388322b5dcacd84361e0d3