### PR TITLE
Refactor error handler to accept invalid inputs

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -145,3 +145,10 @@ test('sanitizeApiKey replaces all matches', () => { //ensure global replacement
   const res = sanitizeApiKey('start key middle key end'); //call with repeated key
   expect(res).toBe('start [redacted] middle [redacted] end'); //expect both replaced
 });
+
+test.each(['plain error', { foo: 'bar' }])('handleAxiosError handles %p input', val => {
+  const { handleAxiosError } = require('../lib/qserp'); //load function under test
+  const res = handleAxiosError(val, 'ctx'); //invoke with arbitrary input
+  expect(res).toBe(true); //should succeed without throwing
+  expect(qerrorsMock).toHaveBeenCalled(); //qerrors should still log
+});

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -235,7 +235,8 @@ function getGoogleURL(query, num) { //accept optional num argument to limit resu
  * It provides consistent logging and uses qerrors for structured error reporting.
  * The function distinguishes between network errors (no response) and HTTP errors (bad status codes).
  * 
- * @param {Error} error - The axios error object containing request/response details
+ * @param {Error|any} error - The axios error object or arbitrary value thrown
+ *   (non-error values are converted into an Error instance)
  * @param {string} contextMsg - Descriptive message about where/why the error occurred
  * @returns {boolean} - true if error was handled successfully, false if handler itself failed
  */
@@ -243,24 +244,27 @@ function handleAxiosError(error, contextMsg) {
         if (DEBUG) { logStart('handleAxiosError', contextMsg); } //debug log gated by DEBUG
 
         try {
-                const sanitized = Object.assign(new Error(), error); //clone properties into new Error object
-                sanitized.message = sanitizeApiKey(error.message); //overwrite message with sanitized value
-                if (error.config && error.config.url) { //preserve other config props
-                        sanitized.config = { ...error.config, url: sanitizeApiKey(error.config.url) }; //sanitize url field
+                let errObj = error instanceof Error ? error : new Error(typeof error === 'string' ? error : JSON.stringify(error)); //ensure Error instance from input
+                if (error && typeof error === 'object' && !(error instanceof Error)) { Object.assign(errObj, error); } //preserve props from plain object
+
+                const sanitized = Object.assign(new Error(), errObj); //clone properties into new Error object
+                sanitized.message = sanitizeApiKey(errObj.message); //overwrite message with sanitized value
+                if (errObj && errObj.config && errObj.config.url) { //check for config before copy
+                        sanitized.config = { ...errObj.config, url: sanitizeApiKey(errObj.config.url) }; //sanitize url field
                 }
 
                 // Differentiate between HTTP errors and network errors for appropriate handling
                 // ERROR CLASSIFICATION STRATEGY: Axios provides different error structures based on failure type
-                if (error.response) {
+                if (errObj && errObj.response) { //check for response before usage
                         // HTTP error: Server responded but with error status (4xx, 5xx)
                         // RESPONSE AVAILABLE: Server was reachable, but rejected the request
                         // Log full response object after sanitizing URL to protect API key
-                        const respCopy = { ...error.response, message: sanitized.message }; //copy response with sanitized msg
+                        const respCopy = { ...errObj.response, message: sanitized.message }; //copy response with sanitized msg
                         if (respCopy.config && respCopy.config.url) {
                                 respCopy.config = { ...respCopy.config, url: sanitizeApiKey(respCopy.config.url) }; //sanitize url in response config
                         }
                         logError(respCopy); //log sanitized response object
-                } else if (error.request) {
+                } else if (errObj && errObj.request) { //check for request before usage
                         // Network error: Request was made but no response received
                         const urlInfo = sanitized.config && sanitized.config.url ? ` url: ${sanitized.config.url}` : ''; //optional sanitized url
                         logError(`Network error: ${sanitized.message}${urlInfo}`); //log sanitized text


### PR DESCRIPTION
## Summary
- improve resilience of `handleAxiosError`
- sanitize Axios error properties safely
- cover conversion of non-error values
- test handling of non-error inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d1161fe84832283a933b409872bfb