### PR TITLE
Improve sanitizeApiKey handling

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -80,17 +80,22 @@ const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
 const { logStart, logReturn } = require('./logUtils'); //standardized logging utilities
 const { logWarn, logError } = require('./minLogger'); //minimal log utility for warn/error
 
-const keyRegex = apiKey ? new RegExp(apiKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //precompute regex for raw api key
-const encKeyRegex = apiKey ? new RegExp(encodeURIComponent(apiKey).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi') : null; //regex for percent encoded key
+const safeKey = apiKey ? apiKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape characters in raw key
+const safeEncKey = apiKey ? encodeURIComponent(apiKey).replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape encoded key
+const keyRegex = apiKey ? new RegExp(safeKey, 'gi') : null; //regex for raw api key case-insensitive
+const encKeyRegex = apiKey ? new RegExp(safeEncKey, 'gi') : null; //regex for percent encoded key case-insensitive
+const keyParamRegex = apiKey ? new RegExp(`key(?:=|%3[dD])(?:${safeKey}|${safeEncKey})`, 'gi') : null; //regex for key= parameter with raw or encoded key
 
 // Utility to mask API key in log messages for security
 function sanitizeApiKey(text) { //replace raw or encoded api key in text
         let result; //final sanitized value holder
         try {
-                result = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //remove raw key
-                result = typeof result === 'string' && encKeyRegex ? result.replace(encKeyRegex, '[redacted]') : result; //remove encoded key
+                result = String(text); //normalize input to string for consistent processing
+                result = keyParamRegex ? result.replace(keyParamRegex, '[redacted]') : result; //remove key= patterns
+                result = keyRegex ? result.replace(keyRegex, '[redacted]') : result; //remove raw key regardless of case
+                result = encKeyRegex ? result.replace(encKeyRegex, '[redacted]') : result; //remove encoded key in any case
         } catch (err) {
-                result = text; //fallback to original when error occurs
+                result = String(text); //fallback to stringified original on error
         }
         if (DEBUG) { console.log(`sanitizeApiKey is running with ${result}`); } //log sanitized input when debug
         if (DEBUG) { console.log(`sanitizeApiKey is returning ${result}`); } //log sanitized output when debug


### PR DESCRIPTION
## Summary
- enhance API key sanitization to handle case-insensitive and encoded keys
- update internal tests for new sanitization behavior
- cover uppercase encoded keys and query string fragments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d115c7a8083228dfe2b97751aa101