### PR TITLE
Improve axios error handling

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -119,6 +119,15 @@ test('handleAxiosError returns false when qerrors throws', () => { //verify fall
   spy.mockRestore(); //restore console.error
 }); //end test ensuring failure path
 
+test.each([null, undefined, {}])('handleAxiosError handles %p gracefully', val => { //verify invalid structures
+  const { handleAxiosError } = require('../lib/qserp'); //load function for test
+  const spy = mockConsole('error'); //intercept error output
+  const res = handleAxiosError(val, 'ctx'); //invoke handler with invalid input
+  expect(res).toBe(false); //should return false for bad structure
+  expect(qerrorsMock).toHaveBeenCalled(); //qerrors invoked for logging
+  spy.mockRestore(); //cleanup spy
+});
+
 test.each(['True', 'true', 'TRUE', true])('rateLimitedRequest returns mock when CODEX=%s', async val => {
   process.env.CODEX = val; //set CODEX variant to trigger mock response
   ({ mock, scheduleMock, qerrorsMock } = initSearchTest()); //reinit with CODEX set

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -243,8 +243,15 @@ function handleAxiosError(error, contextMsg) {
         if (DEBUG) { logStart('handleAxiosError', contextMsg); } //debug log gated by DEBUG
 
         try {
+                if (!error || typeof error !== 'object' || (!error.message && !error.response && !error.request)) { //validate structure is axios-like
+                        qerrors(new Error('Unknown error'), contextMsg, { operation: contextMsg, errorType: 'Unknown' }); //log generic via qerrors
+                        logError('Unknown axios error'); //basic warning for unexpected structure
+                        if (DEBUG) { logReturn('handleAxiosError', false); } //log early return
+                        return false; //indicate unexpected structure handled
+                }
+
                 const sanitized = Object.assign(new Error(), error); //clone properties into new Error object
-                sanitized.message = sanitizeApiKey(error.message); //overwrite message with sanitized value
+                sanitized.message = sanitizeApiKey(error.message || ''); //overwrite message with sanitized value
                 if (error.config && error.config.url) { //preserve other config props
                         sanitized.config = { ...error.config, url: sanitizeApiKey(error.config.url) }; //sanitize url field
                 }


### PR DESCRIPTION
## Summary
- check objects in `handleAxiosError` before accessing properties
- log generic message for non-Axios errors
- test invalid error inputs to verify robustness

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684d114e2ef08322a1dfb145b9902c88