### PR TITLE
Improve API key sanitization

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -145,3 +145,9 @@ test('sanitizeApiKey replaces all matches', () => { //ensure global replacement
   const res = sanitizeApiKey('start key middle key end'); //call with repeated key
   expect(res).toBe('start [redacted] middle [redacted] end'); //expect both replaced
 });
+
+test.each(['Key', 'KEY'])('sanitizeApiKey handles casing for %s', variant => {
+  const { sanitizeApiKey } = require('../lib/qserp'); //import sanitize for variant check
+  const res = sanitizeApiKey(`pre ${variant} post`); //insert variant in string
+  expect(res).toBe('pre [redacted] post'); //verify sanitized regardless of case
+});

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -80,7 +80,7 @@ const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
 const { logStart, logReturn } = require('./logUtils'); //standardized logging utilities
 const { logWarn, logError } = require('./minLogger'); //minimal log utility for warn/error
 
-const keyRegex = apiKey ? new RegExp(apiKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //precompute regex for raw api key
+const keyRegex = apiKey ? new RegExp(apiKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi') : null; //precompute case-insensitive regex for raw api key
 const encKeyRegex = apiKey ? new RegExp(encodeURIComponent(apiKey).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi') : null; //regex for percent encoded key
 
 // Utility to mask API key in log messages for security
@@ -88,6 +88,11 @@ function sanitizeApiKey(text) { //replace raw or encoded api key in text
         let result; //final sanitized value holder
         try {
                 result = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //remove raw key
+                if (typeof result === 'string' && apiKey) { //explicit fallback for differing case
+                        const lowerRx = new RegExp(apiKey.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'); //match lower case key
+                        const upperRx = new RegExp(apiKey.toUpperCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'); //match upper case key
+                        result = result.replace(lowerRx, '[redacted]').replace(upperRx, '[redacted]'); //sanitize both casings
+                }
                 result = typeof result === 'string' && encKeyRegex ? result.replace(encKeyRegex, '[redacted]') : result; //remove encoded key
         } catch (err) {
                 result = text; //fallback to original when error occurs


### PR DESCRIPTION
## Summary
- sanitize API key regardless of case
- ensure `sanitizeApiKey` covers uppercase/lowercase variants
- test case-insensitive removal of API key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d114a30808322a634724be870726f