### PR TITLE
Handle codex mode earlier

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -130,6 +130,17 @@ test.each(['True', 'true', 'TRUE', true])('rateLimitedRequest returns mock when 
   delete process.env.CODEX; //clean up env variable for other tests
 }); //test ensures CODEX casings bypass network
 
+test('fetchSearchItems bypasses url build in CODEX mode', async () => {
+  process.env.CODEX = 'true'; //enable codex offline mode
+  ({ mock, scheduleMock, qerrorsMock } = initSearchTest()); //reinit with codex flag
+  const { fetchSearchItems } = require('../lib/qserp'); //import after env set
+  const items = await fetchSearchItems('offline'); //call fetch expecting mock
+  expect(items).toEqual([]); //mock response should be empty array
+  expect(scheduleMock).not.toHaveBeenCalled(); //rate limiter should not schedule
+  expect(mock.history.get.length).toBe(0); //axios should not build any url
+  delete process.env.CODEX; //cleanup codex flag
+}); //test verifies fetchSearchItems skips url creation when CODEX true
+
 test('validateSearchQuery accepts non-empty strings', () => { //(verify valid input)
   const { validateSearchQuery } = require('../lib/qserp'); //import helper
   expect(validateSearchQuery('ok')).toBe(true); //should return true for normal string

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -364,9 +364,17 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                        }
                }
 
-               const url = getGoogleURL(query, safeNum); //(build search url with clamped num)
+              if (String(process.env.CODEX).toLowerCase() === 'true') { //(mock path when codex true)
+                      const response = await rateLimitedRequest(''); //(bypass URL build and schedule)
+                      const items = response.data.items || []; //(extract mock items array)
+                      if (MAX_CACHE_SIZE !== 0) { cache.set(cacheKey, items); } //cache even in mock mode
+                      if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log mock return)
+                      return items; //return mock array directly
+              }
 
-                const response = await rateLimitedRequest(url); //(perform rate limited axios request)
+              const url = getGoogleURL(query, safeNum); //(build search url with clamped num)
+
+               const response = await rateLimitedRequest(url); //(perform rate limited axios request)
                const items = response.data.items || []; //(extract items array if present)
                
                // Store in LRU cache - TTL and size limits handled automatically


### PR DESCRIPTION
## Summary
- avoid building Google URLs in codex mode
- add regression test for codex mode url generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d11453bec832286a0573af2c0beb0