### PR TITLE
Handle numeric strings in normalizeNum

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -159,6 +159,11 @@ describe('qserp module', () => { //group qserp tests
     expect(url).toBe(`https://www.googleapis.com/customsearch/v1?q=Val&key=key&cx=cx&fields=items(title,snippet,link)&num=${valid}`); //should match num
   });
 
+  test('getGoogleURL accepts numeric string', () => { //verify string parsing and clamping
+    const url = getGoogleURL('Val', '5'); //num provided as string
+    expect(url).toBe('https://www.googleapis.com/customsearch/v1?q=Val&key=key&cx=cx&fields=items(title,snippet,link)&num=5'); //string should parse to num 5
+  });
+
   test.each([0, -1, 11])('getGoogleURL clamps out of range %i', bad => { //invalid values clamp to range
     const url = getGoogleURL('Bad', bad); //build url with invalid num
     const clamped = bad < 1 ? 1 : 10; //expected clamp result

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -195,7 +195,8 @@ warnIfMissingEnvVars(OPTIONAL_VARS, OPENAI_WARN_MSG); //use centralized warning 
 function normalizeNum(num) { //return clamped integer or null for invalid input
        console.log(`normalizeNum is running with ${num}`); //trace start for debug
        try {
-               let safe = Number.isFinite(num) ? Math.floor(num) : null; //ensure finite integer for clamping
+               const parsed = parseInt(num, 10); //parse numeric strings to integers before validation
+               let safe = Number.isFinite(parsed) ? parsed : null; //validate the parsed value is a real number
                if (safe !== null) { safe = Math.min(Math.max(safe, 1), 10); } //clamp between 1 and 10 when provided
                console.log(`normalizeNum is returning ${safe}`); //trace resulting value
                return safe; //propagate normalized number or null


### PR DESCRIPTION
## Summary
- parse numeric strings before validating in `normalizeNum`
- test numeric string input for `getGoogleURL`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d164441a083229ad8ba033e627d2f