### PR TITLE
Improve sanitization logging

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -207,8 +207,8 @@ describe('qserp module', () => { //group qserp tests
     logSpy.mockClear(); //ignore module init logs
     const res = sanitizeApiKey('pre key post'); //call function with api key
     expect(res).toBe('pre [redacted] post'); //result sanitized
-    expect(logSpy).toHaveBeenCalledWith('sanitizeApiKey is running with pre [redacted] post'); //start log sanitized
-    expect(logSpy).toHaveBeenCalledWith('sanitizeApiKey is returning pre [redacted] post'); //return log sanitized
+    expect(logSpy).toHaveBeenNthCalledWith(1, 'sanitizeApiKey is running with pre [redacted] post'); //first log sanitized input
+    expect(logSpy).toHaveBeenNthCalledWith(2, 'sanitizeApiKey is returning pre [redacted] post'); //second log sanitized output
     logSpy.mockRestore(); //cleanup spy
     if (savedDebug !== undefined) { process.env.DEBUG = savedDebug; } else { delete process.env.DEBUG; } //restore env
   });

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -86,13 +86,17 @@ const encKeyRegex = apiKey ? new RegExp(encodeURIComponent(apiKey).replace(/[.*+
 // Utility to mask API key in log messages for security
 function sanitizeApiKey(text) { //replace raw or encoded api key in text
         let result; //final sanitized value holder
+        let sanitizedInput; //input sanitized only for logging
         try {
-                result = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //remove raw key
-                result = typeof result === 'string' && encKeyRegex ? result.replace(encKeyRegex, '[redacted]') : result; //remove encoded key
+                sanitizedInput = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //compute sanitized version
+                sanitizedInput = typeof sanitizedInput === 'string' && encKeyRegex ? sanitizedInput.replace(encKeyRegex, '[redacted]') : sanitizedInput; //handle encoded key
+                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //log sanitized argument before modification
+                result = sanitizedInput; //use sanitized version as result
         } catch (err) {
-                result = text; //fallback to original when error occurs
+                sanitizedInput = text; //fallback sanitized log on error
+                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //log fallback input when debug
+                result = text; //return unmodified text on error
         }
-        if (DEBUG) { console.log(`sanitizeApiKey is running with ${result}`); } //log sanitized input when debug
         if (DEBUG) { console.log(`sanitizeApiKey is returning ${result}`); } //log sanitized output when debug
         return result; //return sanitized value
 }


### PR DESCRIPTION
## Summary
- log sanitized text immediately after receiving input
- verify call order of debug logs in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d1645e3248322bf8ef5dd5dee2874