### PR TITLE
Refactor getGoogleURL env usage

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -59,7 +59,6 @@ test('getGoogleURL builds proper url', () => {
 test('getGoogleURL encodes key and cx values', () => {
   process.env.GOOGLE_API_KEY = 'k+/val'; //set api key with special chars
   process.env.GOOGLE_CX = 'cx/+'; //set cx with special chars
-  jest.resetModules(); //reload module with new env vars
   const { getGoogleURL } = require('../lib/qserp');
   const url = getGoogleURL('encode');
   expect(url).toBe('https://www.googleapis.com/customsearch/v1?q=encode&key=k%2B%2Fval&cx=cx%2F%2B&fields=items(title,snippet,link)'); //encoded key and cx

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -42,8 +42,8 @@ const axiosInstance = axios.create({ //axios instance with keepAlive agents and 
        httpsAgent: new https.Agent({ keepAlive: true, maxSockets: 20, maxFreeSockets: 10 }) //reuse https sockets with connection limits
 });
 const Bottleneck = require('bottleneck'); // Rate limiting library to prevent API quota exhaustion
-const apiKey = process.env.GOOGLE_API_KEY; // Google API key from environment - required for authentication
-const cx = process.env.GOOGLE_CX; // Custom Search Engine ID from environment - defines search scope
+const defaultApiKey = process.env.GOOGLE_API_KEY; // initial api key fallback when env changes
+const defaultCx = process.env.GOOGLE_CX; // initial cx fallback when env changes
 const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility for consistent behavior
 const DEBUG = getDebugFlag(); //flag to toggle verbose logging
 
@@ -80,8 +80,8 @@ const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
 const { logStart, logReturn } = require('./logUtils'); //standardized logging utilities
 const { logWarn, logError } = require('./minLogger'); //minimal log utility for warn/error
 
-const keyRegex = apiKey ? new RegExp(apiKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //precompute regex for raw api key
-const encKeyRegex = apiKey ? new RegExp(encodeURIComponent(apiKey).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi') : null; //regex for percent encoded key
+const keyRegex = defaultApiKey ? new RegExp(defaultApiKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //precompute regex for raw key
+const encKeyRegex = defaultApiKey ? new RegExp(encodeURIComponent(defaultApiKey).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi') : null; //regex for percent encoded key
 
 // Utility to mask API key in log messages for security
 function sanitizeApiKey(text) { //replace raw or encoded api key in text
@@ -217,8 +217,10 @@ function getGoogleURL(query, num) { //accept optional num argument to limit resu
         // Construct base URL with required parameters and optimized field selection
         // FIELDS OPTIMIZATION: Only request title, snippet, link to reduce response payload
         // by ~50-70% compared to full response, improving network performance
-        const encodedKey = encodeURIComponent(apiKey); //url encode api key to handle special chars
-        const encodedCx = encodeURIComponent(cx); //url encode cx id to handle special chars
+        const key = process.env.GOOGLE_API_KEY || defaultApiKey; //read env each call with fallback
+        const searchCx = process.env.GOOGLE_CX || defaultCx; //allow runtime override of cx
+        const encodedKey = encodeURIComponent(key); //url encode dynamic api key
+        const encodedCx = encodeURIComponent(searchCx); //url encode dynamic cx
         const base = `https://www.googleapis.com/customsearch/v1?q=${encodedQuery}&key=${encodedKey}&cx=${encodedCx}&fields=items(title,snippet,link)`; //build base url with encoded creds
 
         // Normalize num parameter to Google's allowed range 1-10


### PR DESCRIPTION
## Summary
- read `GOOGLE_API_KEY` and `GOOGLE_CX` on every `getGoogleURL` call
- default to initial env vars when runtime values missing
- adjust regex setup for sanitized logging
- update test to no longer reload module when changing env vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d165d73248322b2e5a58332878afa