### PR TITLE
Expand offline mock structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ googleSearch('test').then(results => {
 });
 ```
 
+In offline mode `rateLimitedRequest` resolves to:
+
+```javascript
+{ data: { items: [], searchInformation: { searchTime: 0, totalResults: '0' } } }
+```
+
+Only these fields are returned.
+
 This enables development and testing in environments without internet access or API credentials.
 
 ## Caching System

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -124,7 +124,8 @@ test.each(['True', 'true', 'TRUE', true])('rateLimitedRequest returns mock when 
   ({ mock, scheduleMock, qerrorsMock } = initSearchTest()); //reinit with CODEX set
   const { rateLimitedRequest } = require('../lib/qserp'); //import after env setup
   const res = await rateLimitedRequest('http://codex'); //call function expecting mock
-  expect(res).toEqual({ data: { items: [] } }); //mocked empty items returned
+  const expected = { data: { items: [], searchInformation: { searchTime: 0, totalResults: '0' } } }; //expected mock structure
+  expect(res).toEqual(expected); //mocked object should match structure
   expect(scheduleMock).not.toHaveBeenCalled(); //limiter should be bypassed
   expect(mock.history.get.length).toBe(0); //axios should not receive any request
   delete process.env.CODEX; //clean up env variable for other tests

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -148,7 +148,7 @@ async function rateLimitedRequest(url) { //(handle network request with optional
         if (DEBUG) { logStart('rateLimitedRequest', safeUrl); } //(avoid key leak with toggle)
 
         if (String(process.env.CODEX).toLowerCase() === 'true') { //(use case-insensitive true check for codex mock)
-                const mockRes = { data: { items: [] } }; //(define mock axios-like response)
+                const mockRes = { data: { items: [], searchInformation: { searchTime: 0, totalResults: '0' } } }; //(include representative fields in mock)
                 if (DEBUG) { console.log('rateLimitedRequest using codex mock response'); } //(notify mock path taken when debug)
                 if (DEBUG) { logReturn('rateLimitedRequest', JSON.stringify(mockRes)); } //(mock return log when debug)
                 return mockRes; //(return mocked response)


### PR DESCRIPTION
## Summary
- expand the CODEX mock in `rateLimitedRequest` to include `searchInformation`
- document offline response fields in the README
- update offline-mode test expectations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d166081648322a72727baf4d36d7a