### PR TITLE
Add optional referer header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ These variables enhance functionality but are not required:
 - `CODEX` – When set to any case-insensitive `true` value, enables offline mode with mocked responses
 - `LOG_LEVEL` – Controls `warn` and `error` output (`info` by default)
 - `QSERP_MAX_CACHE_SIZE` – Maximum cache entries (default: 1000, range: 10-50000) for memory management
+- `GOOGLE_REFERER` – Adds a Referer header to requests when set
 
 ## Usage
 

--- a/__tests__/constants.test.js
+++ b/__tests__/constants.test.js
@@ -2,6 +2,6 @@ const { REQUIRED_VARS, OPTIONAL_VARS, OPENAI_WARN_MSG } = require('../lib/consta
 
 test('constants arrays have expected entries', () => { //verify exports
   expect(REQUIRED_VARS).toEqual(['GOOGLE_API_KEY', 'GOOGLE_CX']); //should match required list
-  expect(OPTIONAL_VARS).toEqual(['OPENAI_TOKEN']); //should match optional list
+  expect(OPTIONAL_VARS).toEqual(['OPENAI_TOKEN', 'GOOGLE_REFERER']); //should match optional list
   expect(OPENAI_WARN_MSG).toBe('OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.'); //should match warning text
 });

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -20,6 +20,14 @@ test('rateLimitedRequest calls limiter and sets headers', async () => {
   expect(config['User-Agent']).toMatch(/Mozilla/);
 });
 
+test('rateLimitedRequest sets Referer header when env set', async () => {
+  mock.onGet('http://refer').reply(200, {}); //mock axios response
+  const { rateLimitedRequest } = require('../lib/qserp');
+  await rateLimitedRequest('http://refer');
+  const config = mock.history.get[0].headers; //inspect request headers
+  expect(config.Referer).toBe('http://example.com'); //header should match env var
+});
+
 test('rateLimitedRequest uses custom axios instance', async () => { //verify instance path
   mock.onGet('http://inst').reply(200, {}); //mock via instance
   const { rateLimitedRequest, axiosInstance } = require('../lib/qserp');

--- a/__tests__/utils/testSetup.js
+++ b/__tests__/utils/testSetup.js
@@ -46,6 +46,7 @@ function setTestEnv() {
   process.env.GOOGLE_CX = 'cx'; //set common cx id (simple test value)
   // Set optional environment variables to prevent warning messages in tests
   process.env.OPENAI_TOKEN = 'token'; //set common openai token (prevents warnings)
+  process.env.GOOGLE_REFERER = 'http://example.com'; //set referer for header tests
   logReturn('setTestEnv', true); //final log via util
   return true; //confirm env set
 }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -49,7 +49,7 @@ const REQUIRED_VARS = ['GOOGLE_API_KEY', 'GOOGLE_CX'];
  * - Developers should be able to use qserp even without OpenAI access
  * - Error logging will still work, just without AI enhancement
  */
-const OPTIONAL_VARS = ['OPENAI_TOKEN'];
+const OPTIONAL_VARS = ['OPENAI_TOKEN', 'GOOGLE_REFERER']; //referer header optional for custom analytics
 
 /**
  * Warning message when OPENAI_TOKEN is missing

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -162,7 +162,8 @@ async function rateLimitedRequest(url) { //(handle network request with optional
                         headers: {
                                 // User-Agent header mimics Chrome browser to avoid bot detection
                                 // Some APIs may block requests with missing or obvious bot user agents
-                                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36'
+                                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36',
+                                ...(process.env.GOOGLE_REFERER ? { Referer: process.env.GOOGLE_REFERER } : {}) //include referer header when provided
                         }
                 })
         );
@@ -178,7 +179,8 @@ if (String(process.env.CODEX).toLowerCase() !== 'true') { //case-insensitive cod
 
 // Warn about optional environment variables that enhance functionality
 // OPENAI_TOKEN is used by qerrors for enhanced error analysis but isn't strictly required
-warnIfMissingEnvVars(OPTIONAL_VARS, OPENAI_WARN_MSG); //use centralized warning text
+warnIfMissingEnvVars(['OPENAI_TOKEN'], OPENAI_WARN_MSG); //specific warning for qerrors
+warnIfMissingEnvVars(['GOOGLE_REFERER']); //generic warning for optional referer header
 
 /**
  * Generates a Google Custom Search API URL with proper encoding


### PR DESCRIPTION
## Summary
- allow Referer header via `GOOGLE_REFERER` env var
- test Referer header logic and update environment setup
- document optional env var in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d166d59308322ac28ca157a5da6ba