### PR TITLE
Await qerrors in error handlers

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -65,19 +65,19 @@ test('getGoogleURL encodes key and cx values', () => {
   expect(url).toBe('https://www.googleapis.com/customsearch/v1?q=encode&key=k%2B%2Fval&cx=cx%2F%2B&fields=items(title,snippet,link)'); //encoded key and cx
 });
 
-test('handleAxiosError logs with qerrors and returns true', () => {
+test('handleAxiosError logs with qerrors and returns true', async () => {
   const { handleAxiosError } = require('../lib/qserp');
   const err = new Error('fail');
-  const res = handleAxiosError(err, 'ctx');
+  const res = await handleAxiosError(err, 'ctx');
   expect(res).toBe(true);
   expect(qerrorsMock).toHaveBeenCalled();
 });
 
-test('handleAxiosError logs sanitized response object and returns true', () => { //updated test to verify sanitization
+test('handleAxiosError logs sanitized response object and returns true', async () => { //updated test to verify sanitization
   const { handleAxiosError } = require('../lib/qserp'); //require function under test
   const err = { response: { status: 500, config: { url: 'http://x?key=key' } } }; //mock error with key in url
   const spy = mockConsole('error'); //spy on console.error via helper
-  const res = handleAxiosError(err, 'ctx'); //call function with response error
+  const res = await handleAxiosError(err, 'ctx'); //call function with response error
   expect(res).toBe(true); //should return true
   const logged = spy.mock.calls[0][0]; //capture logged object for inspection
   expect(JSON.stringify(logged)).not.toContain('key=key'); //verify key removed from log
@@ -85,35 +85,35 @@ test('handleAxiosError logs sanitized response object and returns true', () => {
   spy.mockRestore(); //restore console.error
 });
 
-test('handleAxiosError masks api key in network error logs', () => {
+test('handleAxiosError masks api key in network error logs', async () => {
   const { handleAxiosError } = require('../lib/qserp'); //load function under test
   const err = { request: {}, message: 'bad key=key', config: { url: 'http://x?key=key' } }; //mock network error with key
   const spy = mockConsole('error'); //spy on console.error
-  const res = handleAxiosError(err, 'ctx'); //call handler
+  const res = await handleAxiosError(err, 'ctx'); //call handler
   expect(res).toBe(true); //should succeed
   const logged = spy.mock.calls[0][0]; //grab logged string
   expect(logged).not.toContain('key=key'); //ensure key removed
   spy.mockRestore(); //cleanup spy
 });
 
-test('handleAxiosError passes sanitized error to qerrors', () => { //verify qerrors arg
+test('handleAxiosError passes sanitized error to qerrors', async () => { //verify qerrors arg
   const { handleAxiosError } = require('../lib/qserp'); //load function
   const err = new Error('bad key=key'); //create error with key in message
   err.config = { url: 'http://x?key=key' }; //attach url containing key
-  handleAxiosError(err, 'ctx'); //invoke handler
+  await handleAxiosError(err, 'ctx'); //invoke handler
   const arg = qerrorsMock.mock.calls[0][0]; //extract error passed to qerrors
   expect(arg).not.toBe(err); //should be copied
   expect(arg.message).toBe('bad [redacted]=[redacted]'); //message sanitized
   expect(arg.config.url).toBe('http://x?[redacted]=[redacted]'); //url sanitized
 });
 
-test('handleAxiosError returns false when qerrors throws', () => { //verify fallback on qerrors failure
+test('handleAxiosError returns false when qerrors throws', async () => { //verify fallback on qerrors failure
   const { handleAxiosError } = require('../lib/qserp'); //load function under test
   const err = new Error('bad'); //mock basic error
   qerrorsMock.mockImplementationOnce(() => { throw new Error('qe'); }); //first call throws
   qerrorsMock.mockImplementation(() => {}); //subsequent calls succeed
   const spy = mockConsole('error'); //spy on console.error via helper
-  const res = handleAxiosError(err, 'ctx'); //invoke handler expecting false
+  const res = await handleAxiosError(err, 'ctx'); //invoke handler expecting false
   expect(res).toBe(false); //should return false due to catch block
   expect(spy).toHaveBeenCalled(); //console.error should log error message
   spy.mockRestore(); //restore console.error
@@ -157,9 +157,9 @@ test('sanitizeApiKey replaces all matches', () => { //ensure global replacement
   expect(res).toBe('start [redacted] middle [redacted] end'); //expect both replaced
 });
 
-test.each(['plain error', { foo: 'bar' }])('handleAxiosError handles %p input', val => {
+test.each(['plain error', { foo: 'bar' }])('handleAxiosError handles %p input', async val => {
   const { handleAxiosError } = require('../lib/qserp'); //load function under test
-  const res = handleAxiosError(val, 'ctx'); //invoke with arbitrary input
+  const res = await handleAxiosError(val, 'ctx'); //invoke with arbitrary input
   expect(res).toBe(true); //should succeed without throwing
   expect(qerrorsMock).toHaveBeenCalled(); //qerrors should still log
 });

--- a/__tests__/qerrorsLoader.test.js
+++ b/__tests__/qerrorsLoader.test.js
@@ -38,30 +38,32 @@ describe('loadQerrors', () => { //group loader tests
 });
 
 describe('safeQerrors', () => { //new tests for sanitized logging
-  test('logStart omits error message', () => {
+  test('logStart omits error message', async () => {
+    let safeQerrors, spy, mockConsole;
     jest.isolateModules(() => { //isolate module for mocking
       const qerr = jest.fn(); //mock qerrors
       jest.doMock('qerrors', () => qerr); //provide mock implementation
-      const { safeQerrors } = require('../lib/qerrorsLoader'); //load function
-      const { mockConsole } = require('./utils/consoleSpies'); //console spy helper
-      const spy = mockConsole('log'); //spy on console.log
-      safeQerrors(new Error('secret'), 'ctx'); //invoke with error
-      expect(spy).toHaveBeenCalledWith('safeQerrors is running with ctx'); //should log generic context only
-      spy.mockRestore(); //cleanup spy
+      ({ safeQerrors } = require('../lib/qerrorsLoader')); //load function
+      ({ mockConsole } = require('./utils/consoleSpies')); //import helper
+      spy = mockConsole('log'); //spy on console.log
     });
+    await safeQerrors(new Error('secret'), 'ctx'); //invoke with error
+    expect(spy).toHaveBeenCalledWith('safeQerrors is running with ctx'); //should log generic context only
+    spy.mockRestore(); //cleanup spy
   });
 
-  test('fallback logs sanitized message', () => {
+  test('fallback logs sanitized message', async () => {
+    let safeQerrors, spy, mockConsole;
     jest.isolateModules(() => { //isolate module for mocking
       const qerr = jest.fn(() => { throw new Error('fail'); }); //mock throwing
       jest.doMock('qerrors', () => qerr); //mock module
-      const { safeQerrors } = require('../lib/qerrorsLoader'); //load function
-      const { mockConsole } = require('./utils/consoleSpies'); //console helper
-      const spy = mockConsole('error'); //spy on console.error
-      safeQerrors(new Error('bad\nline'), 'ctx'); //invoke with newline
-      const joined = spy.mock.calls.map(c => c.join(' ')).join(' '); //aggregate output
-      expect(joined).not.toMatch(/\n/); //newline should be removed
-      spy.mockRestore(); //cleanup
+      ({ safeQerrors } = require('../lib/qerrorsLoader')); //load function
+      ({ mockConsole } = require('./utils/consoleSpies')); //console helper
+      spy = mockConsole('error'); //spy on console.error
     });
+    await safeQerrors(new Error('bad\nline'), 'ctx'); //invoke with newline
+    const joined = spy.mock.calls.map(c => c.join(' ')).join(' '); //aggregate output
+    expect(joined).not.toMatch(/\n/); //newline should be removed
+    spy.mockRestore(); //cleanup
   });
 });

--- a/advanced-security-test.js
+++ b/advanced-security-test.js
@@ -198,7 +198,7 @@ async function advancedSecurityTesting() {
     
     for (const test of errorTests) { // each test should not throw unexpectedly
         try {
-            const result = test();
+            const result = await test(); //await async handler
             if (result === false) {
                 errorHandlingIssues++;
             }

--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -72,9 +72,9 @@ function loadQerrors() {
  * @param {Error|string} error - Error object or message to report
  * @param {string} context - Contextual information about where error occurred
  * @param {Object} additionalData - Additional structured data for error analysis
- * @returns {boolean} - True if error was reported successfully, false if qerrors failed
+ * @returns {Promise<*>} - Result from qerrors or false on failure
  */
-function safeQerrors(error, context, additionalData = {}) {
+async function safeQerrors(error, context, additionalData = {}) { //async to return awaited qerrors result
         logStart('safeQerrors', context); //avoid leaking raw error message
 
         const safeMsg = String(error?.message || error).replace(/\n/g, ' '); //newline sanitize for later logs
@@ -85,9 +85,9 @@ function safeQerrors(error, context, additionalData = {}) {
                 // Ensure error is an Error object for qerrors v1.2.3+ compatibility
                 const errorObj = error instanceof Error ? error : new Error(safeMsg); //use sanitized message when wrapping
                 
-                qerrors(errorObj, context, additionalData);
-                logReturn('safeQerrors', 'success');
-                return true;
+                const result = await qerrors(errorObj, context, additionalData); //await qerrors call for async modules
+                logReturn('safeQerrors', result); //log returned value
+                return result; //propagate qerrors result
         } catch (qerrorsError) {
                 // qerrors itself failed - fall back to basic logging
                 try {

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -238,9 +238,9 @@ function getGoogleURL(query, num) { //accept optional num argument to limit resu
  * @param {Error|any} error - The axios error object or arbitrary value thrown
  *   (non-error values are converted into an Error instance)
  * @param {string} contextMsg - Descriptive message about where/why the error occurred
- * @returns {boolean} - true if error was handled successfully, false if handler itself failed
+ * @returns {Promise<boolean>} - true if error was handled successfully, false if handler itself failed
  */
-function handleAxiosError(error, contextMsg) {
+async function handleAxiosError(error, contextMsg) { //async to await qerrors result
         if (DEBUG) { logStart('handleAxiosError', contextMsg); } //debug log gated by DEBUG
 
         try {
@@ -276,14 +276,14 @@ function handleAxiosError(error, contextMsg) {
 
                 // Use qerrors for structured error logging with sanitized copy
                 // STRUCTURED REPORTING: Enables error aggregation, monitoring, and analysis without leaking secrets
-                qerrors(sanitized, contextMsg, { operation: contextMsg, errorType: sanitized.name });
+                await qerrors(sanitized, contextMsg, { operation: contextMsg, errorType: sanitized.name }); //await async qerrors call
                 
                 if (DEBUG) { logReturn('handleAxiosError', true); } //log return when debug
                 return true; // Indicate error was handled successfully
         } catch (err) {
                 // Error occurred within the error handler itself
                 // Attempt logging the secondary error and keep flow stable
-                try { qerrors(err, 'handleAxiosError error', {contextMsg}); } //log secondary error //(attempt qerrors)
+                try { await qerrors(err, 'handleAxiosError error', {contextMsg}); } //await fallback qerrors //(ensure async wait)
                 catch (qe) { logError(qe); } //fallback logging via utility //(prevent crash)
                 if (DEBUG) { logReturn('handleAxiosError', false); } //log failure when debug
                 return false; // Indicate error handling failed
@@ -387,7 +387,7 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                 if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log return value when debug)
                 return items; //(return extracted items array)
         } catch (error) {
-                handleAxiosError(error, `Error in fetchSearchItems for query: ${query}`); //(handle and log any axios errors)
+                await handleAxiosError(error, `Error in fetchSearchItems for query: ${query}`); //await async error handler
                 if (DEBUG) { logReturn('fetchSearchItems', '[]'); } //(log empty array when debug)
                 return []; //(gracefully return empty array)
         }

--- a/security-test.js
+++ b/security-test.js
@@ -133,7 +133,7 @@ async function securityPenetrationTest() {
     };
     
     try {
-        qserp.handleAxiosError(mockError, 'test context');
+        await qserp.handleAxiosError(mockError, 'test context'); //await async handler
         console.log('✅ Error handling completed without throwing');
     } catch (error) {
         if (error.message.includes('secret123')) {


### PR DESCRIPTION
## Summary
- make `handleAxiosError` async and await qerrors
- return awaited result from `safeQerrors`
- update fetch error handling to await new async function
- adjust unit tests for asynchronous behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d16712f3883229e5bedfb62277b11