### PR TITLE
Skip request in CODEX mode

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -133,13 +133,16 @@ test.each(['True', 'true', 'TRUE', true])('rateLimitedRequest returns mock when 
 test('fetchSearchItems bypasses url build in CODEX mode', async () => {
   process.env.CODEX = 'true'; //enable codex offline mode
   ({ mock, scheduleMock, qerrorsMock } = initSearchTest()); //reinit with codex flag
-  const { fetchSearchItems } = require('../lib/qserp'); //import after env set
-  const items = await fetchSearchItems('offline'); //call fetch expecting mock
+  const qserp = require('../lib/qserp'); //import after env set
+  const spy = jest.spyOn(qserp, 'rateLimitedRequest'); //spy on internal request function
+  const items = await qserp.fetchSearchItems('offline'); //call fetch expecting mock
   expect(items).toEqual([]); //mock response should be empty array
   expect(scheduleMock).not.toHaveBeenCalled(); //rate limiter should not schedule
   expect(mock.history.get.length).toBe(0); //axios should not build any url
+  expect(spy).not.toHaveBeenCalled(); //verify no call to rateLimitedRequest
+  spy.mockRestore(); //clean up spy
   delete process.env.CODEX; //cleanup codex flag
-}); //test verifies fetchSearchItems skips url creation when CODEX true
+}); //test verifies fetchSearchItems skips url creation and internal request when CODEX true
 
 test('validateSearchQuery accepts non-empty strings', () => { //(verify valid input)
   const { validateSearchQuery } = require('../lib/qserp'); //import helper

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -369,11 +369,10 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                }
 
               if (String(process.env.CODEX).toLowerCase() === 'true') { //(mock path when codex true)
-                      const response = await rateLimitedRequest(''); //(bypass URL build and schedule)
-                      const items = response.data.items || []; //(extract mock items array)
-                      if (MAX_CACHE_SIZE !== 0) { cache.set(cacheKey, items); } //cache even in mock mode
+                      const items = []; //use static empty array without network call
+                      if (MAX_CACHE_SIZE !== 0) { cache.set(cacheKey, items); } //still populate cache for consistency
                       if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log mock return)
-                      return items; //return mock array directly
+                      return items; //return mock array directly without calling rateLimitedRequest
               }
 
               const url = getGoogleURL(query, safeNum); //(build search url with clamped num)


### PR DESCRIPTION
## Summary
- avoid calling `rateLimitedRequest` when `CODEX` mode is active
- assert that `rateLimitedRequest` is not invoked in CODEX tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684d1676116883228016bf4ae3d39887