### PR TITLE
Implement env var length validation

### DIFF
--- a/__tests__/envLengthValidation.test.js
+++ b/__tests__/envLengthValidation.test.js
@@ -1,0 +1,27 @@
+const { saveEnv, restoreEnv } = require('./utils/testSetup');
+
+let savedEnv;
+
+beforeEach(() => {
+  savedEnv = saveEnv();
+  jest.resetModules();
+});
+
+afterEach(() => {
+  restoreEnv(savedEnv);
+  jest.resetModules();
+});
+
+test('throws error when GOOGLE_API_KEY exceeds max length', () => {
+  process.env.GOOGLE_API_KEY = 'a'.repeat(257);
+  process.env.GOOGLE_CX = 'cx';
+  process.env.OPENAI_TOKEN = 'token';
+  expect(() => require('../lib/qserp')).toThrow('GOOGLE_API_KEY exceeds maximum length');
+});
+
+test('throws error when GOOGLE_CX exceeds max length', () => {
+  process.env.GOOGLE_API_KEY = 'key';
+  process.env.GOOGLE_CX = 'c'.repeat(257);
+  process.env.OPENAI_TOKEN = 'token';
+  expect(() => require('../lib/qserp')).toThrow('GOOGLE_CX exceeds maximum length');
+});

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -42,8 +42,16 @@ const axiosInstance = axios.create({ //axios instance with keepAlive agents and 
        httpsAgent: new https.Agent({ keepAlive: true, maxSockets: 20, maxFreeSockets: 10 }) //reuse https sockets with connection limits
 });
 const Bottleneck = require('bottleneck'); // Rate limiting library to prevent API quota exhaustion
-const apiKey = process.env.GOOGLE_API_KEY; // Google API key from environment - required for authentication
-const cx = process.env.GOOGLE_CX; // Custom Search Engine ID from environment - defines search scope
+const { parseStringVar } = require('./envValidator'); //string validation utility for env vars
+const MAX_VAR_LENGTH = 256; //max length for sensitive env vars
+const apiKey = parseStringVar('GOOGLE_API_KEY', '', MAX_VAR_LENGTH); //parse and trim api key
+if (process.env.GOOGLE_API_KEY && process.env.GOOGLE_API_KEY.trim().length > MAX_VAR_LENGTH) { //enforce length limit
+        throw new Error(`GOOGLE_API_KEY exceeds maximum length of ${MAX_VAR_LENGTH} characters`); //fail fast on oversize key
+}
+const cx = parseStringVar('GOOGLE_CX', '', MAX_VAR_LENGTH); //parse and trim cx id
+if (process.env.GOOGLE_CX && process.env.GOOGLE_CX.trim().length > MAX_VAR_LENGTH) { //enforce length limit
+        throw new Error(`GOOGLE_CX exceeds maximum length of ${MAX_VAR_LENGTH} characters`); //fail fast on oversize cx id
+}
 const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility for consistent behavior
 const DEBUG = getDebugFlag(); //flag to toggle verbose logging
 


### PR DESCRIPTION
## Summary
- enforce 256 char max for `GOOGLE_API_KEY` and `GOOGLE_CX`
- throw when limits exceeded during module load
- test environment variable length validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d167b52108322a320651936a76b17