### PR TITLE
Add query length validation

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -56,6 +56,13 @@ describe('qserp module', () => { //group qserp tests
     expect(emptyUrls).toEqual([]); //expect empty array result
   });
 
+  test('rejects overly long query strings', async () => { //new max length validation test
+    const long = 'a'.repeat(2050); //construct query exceeding limit
+    await expect(googleSearch(long)).rejects.toThrow(); //should throw via helper
+    await expect(fetchSearchItems(long)).rejects.toThrow(); //helper should also throw
+    await expect(getTopSearchResults([long])).rejects.toThrow(); //multi search should reject
+  });
+
   test('logs errors via helper on request failure', async () => { //verify error logging path
     mock.onGet(/customsearch/).reply(500); //mock failed request
     const res = await googleSearch('err'); //search expecting failure

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -305,6 +305,10 @@ function validateSearchQuery(query) {
                 if (DEBUG) { console.log('validateSearchQuery throwing Query must be a non-empty string'); } //(log failure when debug)
                 throw new Error('Query must be a non-empty string'); //(throw on invalid input)
         }
+        if (query.length > 2048) { //(enforce max character length)
+                if (DEBUG) { console.log('validateSearchQuery throwing Query exceeds 2048 characters'); } //(log failure when debug)
+                throw new Error('Query exceeds 2048 character limit'); //(throw on overly long input)
+        }
         if (DEBUG) { logReturn('validateSearchQuery', true); } //(log success when debug)
         return true; //(confirm valid query)
 }


### PR DESCRIPTION
## Summary
- validate that search queries do not exceed 2048 characters
- test that very long search terms are rejected

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684d168514bc8322b55ff03402d3f2be