### PR TITLE
Use minLogger in envUtils

### DIFF
--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -15,6 +15,7 @@ const qerrors = require('./qerrorsLoader')(); //retrieve qerrors function via lo
 const { logStart, logReturn } = require('./logUtils'); //import standardized log utilities
 const { safeRun } = require('./utils'); //import safeRun utility for common error handling
 const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility
+const { logWarn, logError } = require('./minLogger'); //minimal logging for warn/error
 const DEBUG = getDebugFlag(); //determine current debug state
 
 /**
@@ -62,7 +63,7 @@ function throwIfMissingEnvVars(varArr) {
                // Log error before throwing to ensure visibility even if exception is caught
                // VISIBILITY RATIONALE: Some calling code might catch and handle the exception,
                // but we still want the error logged for debugging and monitoring purposes
-               console.error(errorMessage);
+                logError(errorMessage); //use minLogger instead of console.error
                
                const err = new Error(errorMessage);
                
@@ -104,7 +105,7 @@ function warnIfMissingEnvVars(varArr, customMessage = '') {
                // Use console.warn for optional variables to distinguish from errors
                // WARNING LEVEL: Indicates potential issues without blocking execution,
                // allowing graceful degradation of non-critical functionality
-               console.warn(warningMessage);
+                logWarn(warningMessage); //use minLogger instead of console.warn
        }
 
        const result = missingEnvVars.length === 0; //determine if any vars missing //(compute boolean)


### PR DESCRIPTION
## Summary
- wire up logWarn and logError from minLogger inside envUtils
- adjust tests to check minLogger output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d168bc57c8322add2c0cb3ab45c8a