### PR TITLE
Fix sanitizeApiKey dynamic key handling

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -80,16 +80,15 @@ const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
 const { logStart, logReturn } = require('./logUtils'); //standardized logging utilities
 const { logWarn, logError } = require('./minLogger'); //minimal log utility for warn/error
 
-const keyRegex = defaultApiKey ? new RegExp(defaultApiKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //precompute regex for raw key
-const encKeyRegex = defaultApiKey ? new RegExp(encodeURIComponent(defaultApiKey).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi') : null; //regex for percent encoded key
-
-// Utility to mask API key in log messages for security
 function sanitizeApiKey(text) { //replace raw or encoded api key in text
         let result; //final sanitized value holder
         let sanitizedInput; //input sanitized only for logging
         try {
-                sanitizedInput = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //compute sanitized version
-                sanitizedInput = typeof sanitizedInput === 'string' && encKeyRegex ? sanitizedInput.replace(encKeyRegex, '[redacted]') : sanitizedInput; //handle encoded key
+                const currentKey = process.env.GOOGLE_API_KEY || defaultApiKey; //read current key to handle runtime changes
+                const keyRegex = currentKey ? new RegExp(currentKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //create regex for raw key each call
+                const encKeyRegex = currentKey ? new RegExp(encodeURIComponent(currentKey).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi') : null; //create regex for encoded key each call
+                sanitizedInput = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //replace raw key
+                sanitizedInput = typeof sanitizedInput === 'string' && encKeyRegex ? sanitizedInput.replace(encKeyRegex, '[redacted]') : sanitizedInput; //replace encoded key
                 if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //log sanitized argument before modification
                 result = sanitizedInput; //use sanitized version as result
         } catch (err) {


### PR DESCRIPTION
## Summary
- regenerate API key regex inside `sanitizeApiKey`
- ensure logging sanitizes updated keys
- test updated behavior when API key changes at runtime

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d4737bc4c8322b68c4b7380186021