### PR TITLE
Update offline mock structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,10 @@ googleSearch('test').then(results => {
 In offline mode `rateLimitedRequest` resolves to:
 
 ```javascript
-{ data: { items: [], searchInformation: { searchTime: 0, totalResults: '0' } } }
+{ data: { items: [] } }
 ```
 
-Only these fields are returned.
+Only the items array is returned.
 
 This enables development and testing in environments without internet access or API credentials.
 

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -131,7 +131,7 @@ test.each(['True', 'true', 'TRUE', true])('rateLimitedRequest returns mock when 
   ({ mock, scheduleMock, qerrorsMock } = initSearchTest()); //reinit with CODEX set
   const { rateLimitedRequest } = require('../lib/qserp'); //import after env setup
   const res = await rateLimitedRequest('http://codex'); //call function expecting mock
-  const expected = { data: { items: [], searchInformation: { searchTime: 0, totalResults: '0' } } }; //expected mock structure
+  const expected = { data: { items: [] } }; //expected mock structure
   expect(res).toEqual(expected); //mocked object should match structure
   expect(scheduleMock).not.toHaveBeenCalled(); //limiter should be bypassed
   expect(mock.history.get.length).toBe(0); //axios should not receive any request

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -152,7 +152,7 @@ async function rateLimitedRequest(url) { //(handle network request with optional
         if (DEBUG) { logStart('rateLimitedRequest', safeUrl); } //(avoid key leak with toggle)
 
         if (String(process.env.CODEX).toLowerCase() === 'true') { //(use case-insensitive true check for codex mock)
-                const mockRes = { data: { items: [], searchInformation: { searchTime: 0, totalResults: '0' } } }; //(include representative fields in mock)
+                const mockRes = { data: { items: [] } }; //(return only items array to match offline mode)
                 if (DEBUG) { console.log('rateLimitedRequest using codex mock response'); } //(notify mock path taken when debug)
                 if (DEBUG) { logReturn('rateLimitedRequest', JSON.stringify(mockRes)); } //(mock return log when debug)
                 return mockRes; //(return mocked response)


### PR DESCRIPTION
## Summary
- simplify mock response in `rateLimitedRequest`
- document new offline return object
- adjust test expectations for CODEX mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d4739b1308322b95d2793a02e5eaa