### PR TITLE
Update Google Custom Search API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Before using the module, set these required environment variables:
 - `GOOGLE_API_KEY` – Your Google API key. Obtain from the [Google Cloud Console](https://console.cloud.google.com/)
 - `GOOGLE_CX` – Your Custom Search Engine ID. Set up at [Google Programmable Search Engine](https://programmablesearchengine.google.com/)
 Both values are URL encoded internally so keys containing characters like `+` or `/` work without additional configuration.
+All API requests are sent to `https://customsearch.googleapis.com/customsearch/v1`.
 
 ### Optional Variables
 These variables enhance functionality but are not required:

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -53,15 +53,15 @@ test('fetchSearchItems returns items and uses num argument', async () => { //ens
   const items = await fetchSearchItems('term', 2); //invoke helper with num
   expect(items).toEqual([{ link: 'x' }]); //check items array
   expect(scheduleMock).toHaveBeenCalled(); //ensure schedule used
-  expect(mock.history.get[0].url).toBe('https://www.googleapis.com/customsearch/v1?q=term&key=key&cx=cx&fields=items(title,snippet,link)&num=2'); //url should include num and fields filter
+  expect(mock.history.get[0].url).toBe('https://customsearch.googleapis.com/customsearch/v1?q=term&key=key&cx=cx&fields=items(title,snippet,link)&num=2'); //url should include num and fields filter
 });
 
 test('getGoogleURL builds proper url', () => {
   const { getGoogleURL } = require('../lib/qserp');
   const url = getGoogleURL('hello world');
-  expect(url).toBe('https://www.googleapis.com/customsearch/v1?q=hello%20world&key=key&cx=cx&fields=items(title,snippet,link)');
+  expect(url).toBe('https://customsearch.googleapis.com/customsearch/v1?q=hello%20world&key=key&cx=cx&fields=items(title,snippet,link)');
   const urlNum = getGoogleURL('hello', 5); //pass num argument
-  expect(urlNum).toBe('https://www.googleapis.com/customsearch/v1?q=hello&key=key&cx=cx&fields=items(title,snippet,link)&num=5'); //should include num param and fields filter
+  expect(urlNum).toBe('https://customsearch.googleapis.com/customsearch/v1?q=hello&key=key&cx=cx&fields=items(title,snippet,link)&num=5'); //should include num param and fields filter
 });
 
 test('getGoogleURL encodes key and cx values', () => {
@@ -69,7 +69,7 @@ test('getGoogleURL encodes key and cx values', () => {
   process.env.GOOGLE_CX = 'cx/+'; //set cx with special chars
   const { getGoogleURL } = require('../lib/qserp');
   const url = getGoogleURL('encode');
-  expect(url).toBe('https://www.googleapis.com/customsearch/v1?q=encode&key=k%2B%2Fval&cx=cx%2F%2B&fields=items(title,snippet,link)'); //encoded key and cx
+  expect(url).toBe('https://customsearch.googleapis.com/customsearch/v1?q=encode&key=k%2B%2Fval&cx=cx%2F%2B&fields=items(title,snippet,link)'); //encoded key and cx
 });
 
 test('handleAxiosError logs with qerrors and returns true', async () => {

--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -45,7 +45,7 @@ describe('qserp module', () => { //group qserp tests
   test('getTopSearchResults requests single item', async () => { //ensure num param used
     mock.onGet(/Solo/).reply(200, { items: [{ link: 'http://s' }] }); //mock single term
     await getTopSearchResults(['Solo']); //call with one term
-    expect(mock.history.get[0].url).toBe('https://www.googleapis.com/customsearch/v1?q=Solo&key=key&cx=cx&fields=items(title,snippet,link)&num=1'); //url should request one item with fields filter
+    expect(mock.history.get[0].url).toBe('https://customsearch.googleapis.com/customsearch/v1?q=Solo&key=key&cx=cx&fields=items(title,snippet,link)&num=1'); //url should request one item with fields filter
   });
 
   test('handles empty or invalid input', async () => { //verify validation paths
@@ -163,18 +163,18 @@ describe('qserp module', () => { //group qserp tests
 
   test.each([1, 5, 10])('getGoogleURL includes valid num %i', valid => { //verify clamped url for valid num
     const url = getGoogleURL('Val', valid); //build url with provided num
-    expect(url).toBe(`https://www.googleapis.com/customsearch/v1?q=Val&key=key&cx=cx&fields=items(title,snippet,link)&num=${valid}`); //should match num
+    expect(url).toBe(`https://customsearch.googleapis.com/customsearch/v1?q=Val&key=key&cx=cx&fields=items(title,snippet,link)&num=${valid}`); //should match num
   });
 
   test('getGoogleURL accepts numeric string', () => { //verify string parsing and clamping
     const url = getGoogleURL('Val', '5'); //num provided as string
-    expect(url).toBe('https://www.googleapis.com/customsearch/v1?q=Val&key=key&cx=cx&fields=items(title,snippet,link)&num=5'); //string should parse to num 5
+    expect(url).toBe('https://customsearch.googleapis.com/customsearch/v1?q=Val&key=key&cx=cx&fields=items(title,snippet,link)&num=5'); //string should parse to num 5
   });
 
   test.each([0, -1, 11])('getGoogleURL clamps out of range %i', bad => { //invalid values clamp to range
     const url = getGoogleURL('Bad', bad); //build url with invalid num
     const clamped = bad < 1 ? 1 : 10; //expected clamp result
-    expect(url).toBe(`https://www.googleapis.com/customsearch/v1?q=Bad&key=key&cx=cx&fields=items(title,snippet,link)&num=${clamped}`); //should clamp
+    expect(url).toBe(`https://customsearch.googleapis.com/customsearch/v1?q=Bad&key=key&cx=cx&fields=items(title,snippet,link)&num=${clamped}`); //should clamp
   });
 
   test('disables caching when env var is zero', async () => { //new zero cache test

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -228,7 +228,7 @@ function getGoogleURL(query, num) { //accept optional num argument to limit resu
         const searchCx = process.env.GOOGLE_CX || defaultCx; //allow runtime override of cx
         const encodedKey = encodeURIComponent(key); //url encode dynamic api key
         const encodedCx = encodeURIComponent(searchCx); //url encode dynamic cx
-        const base = `https://www.googleapis.com/customsearch/v1?q=${encodedQuery}&key=${encodedKey}&cx=${encodedCx}&fields=items(title,snippet,link)`; //build base url with encoded creds
+        const base = `https://customsearch.googleapis.com/customsearch/v1?q=${encodedQuery}&key=${encodedKey}&cx=${encodedCx}&fields=items(title,snippet,link)`; //update to current Google endpoint
 
         // Normalize num parameter to Google's allowed range 1-10
         // REUSE LOGIC: Delegates clamping to normalizeNum for consistency


### PR DESCRIPTION
## Summary
- use `https://customsearch.googleapis.com/customsearch/v1` in Google URL builder
- update tests to reflect new endpoint
- document the new endpoint in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d475096e88322904c8a974e131ac2