### PR TITLE
fix sanitizeApiKey dynamic regex

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -168,6 +168,15 @@ test('sanitizeApiKey replaces all matches', () => { //ensure global replacement
   expect(res).toBe('start [redacted] middle [redacted] end'); //expect both replaced
 });
 
+test('sanitizeApiKey reacts to changed GOOGLE_API_KEY after load', () => { //verify runtime key change
+  const { sanitizeApiKey } = require('../lib/qserp'); //use already loaded module
+  process.env.GOOGLE_API_KEY = 'newkey'; //change key without reloading module
+  const raw = sanitizeApiKey('pre newkey post'); //sanitize raw key
+  const enc = sanitizeApiKey(`pre ${encodeURIComponent('newkey')} post`); //sanitize encoded key
+  expect(raw).toBe('pre [redacted] post'); //raw sanitized
+  expect(enc).toBe('pre [redacted] post'); //encoded sanitized
+});
+
 test.each(['plain error', { foo: 'bar' }])('handleAxiosError handles %p input', async val => {
   const { handleAxiosError } = require('../lib/qserp'); //load function under test
   const res = await handleAxiosError(val, 'ctx'); //invoke with arbitrary input

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -80,17 +80,18 @@ const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
 const { logStart, logReturn } = require('./logUtils'); //standardized logging utilities
 const { logWarn, logError } = require('./minLogger'); //minimal log utility for warn/error
 
-const keyRegex = defaultApiKey ? new RegExp(defaultApiKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //precompute regex for raw key
-const encKeyRegex = defaultApiKey ? new RegExp(encodeURIComponent(defaultApiKey).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi') : null; //regex for percent encoded key
 
 // Utility to mask API key in log messages for security
-function sanitizeApiKey(text) { //replace raw or encoded api key in text
+function sanitizeApiKey(text) { //replace raw or encoded api key in text each call builds regex
         let result; //final sanitized value holder
         let sanitizedInput; //input sanitized only for logging
         try {
-                sanitizedInput = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //compute sanitized version
-                sanitizedInput = typeof sanitizedInput === 'string' && encKeyRegex ? sanitizedInput.replace(encKeyRegex, '[redacted]') : sanitizedInput; //handle encoded key
-                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //log sanitized argument before modification
+                const key = process.env.GOOGLE_API_KEY || defaultApiKey; //read current key for regex
+                const rawRegex = key ? new RegExp(key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //create raw key regex
+                const encodedRegex = key ? new RegExp(encodeURIComponent(key).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi') : null; //create encoded key regex
+                sanitizedInput = typeof text === 'string' && rawRegex ? text.replace(rawRegex, '[redacted]') : text; //apply raw regex
+                sanitizedInput = typeof sanitizedInput === 'string' && encodedRegex ? sanitizedInput.replace(encodedRegex, '[redacted]') : sanitizedInput; //apply encoded regex
+                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //log sanitized input when debug
                 result = sanitizedInput; //use sanitized version as result
         } catch (err) {
                 sanitizedInput = text; //fallback sanitized log on error


### PR DESCRIPTION
## Summary
- compute API key regexes inside `sanitizeApiKey`
- test that runtime GOOGLE_API_KEY changes are sanitized

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d476a665083228a13b5f7e1831da1