### PR TITLE
Fix radix parsing for env variables

### DIFF
--- a/__tests__/envValidator.test.js
+++ b/__tests__/envValidator.test.js
@@ -111,6 +111,15 @@ describe('envValidator', () => {
             expect(debugReturn).toHaveBeenCalledWith('parseIntWithBounds', 0);
         });
 
+        it('should parse values with leading zeros as decimal', () => {
+            process.env.TEST_VAR = '08';
+
+            const result = parseIntWithBounds('TEST_VAR', 50, 0, 100);
+
+            expect(result).toBe(8); //explicit base 10 prevents octal interpretation
+            expect(debugReturn).toHaveBeenCalledWith('parseIntWithBounds', 8);
+        });
+
         it('should handle boundary values exactly at limits', () => {
             process.env.TEST_VAR = '10';
             

--- a/advanced-security-test.js
+++ b/advanced-security-test.js
@@ -101,7 +101,7 @@ async function advancedSecurityTesting() {
         
         try {
             // Test if malicious env values cause issues
-            const parsedValue = parseInt(process.env.QSERP_MAX_CACHE_SIZE) || 1000;
+            const parsedValue = parseInt(process.env.QSERP_MAX_CACHE_SIZE, 10) || 1000; //use base 10 to match production parsing
             if (parsedValue < 0 || parsedValue > 100000 || isNaN(parsedValue)) {
                 console.log(`Environment validation needed for ${test.key}=${test.value}`);
             } else {

--- a/lib/envValidator.js
+++ b/lib/envValidator.js
@@ -35,7 +35,7 @@ function parseIntWithBounds(varName, defaultValue, minValue, maxValue) {
     // Parse environment variable with proper zero handling
     // ZERO VALUE FIX: Use isNaN check instead of || operator to allow legitimate zero values
     // This prevents configuration issues where 0 is a valid setting (cache disabled, unlimited rate)
-    const envValue = parseInt(process.env[varName]);
+    const envValue = parseInt(process.env[varName], 10); //explicit base 10 avoids octal issues
     const rawValue = !isNaN(envValue) ? envValue : defaultValue;
     
     // Apply bounds checking for security and stability


### PR DESCRIPTION
## Summary
- ensure `parseInt` uses radix 10 in `parseIntWithBounds`
- fix security test to match parsing logic
- test leading zero handling for env parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d476ddc988322864eb7e58eb5a44b