### PR TITLE
Improve logging across utilities

### DIFF
--- a/lib/errorUtils.js
+++ b/lib/errorUtils.js
@@ -18,6 +18,7 @@
  */
 
 const qerrors = require('./qerrorsLoader')();
+const { logStart, logReturn } = require('./logUtils'); //logging utilities for tracing
 
 /**
  * Creates standardized error context for API/network operations
@@ -30,12 +31,15 @@ const qerrors = require('./qerrorsLoader')();
  * @returns {Object} Standardized error context object
  */
 function createApiErrorContext(operation, details = {}) {
-        return {
-                category: 'api_error',
-                operation,
-                timestamp: new Date().toISOString(),
-                ...details
+        logStart('createApiErrorContext', operation); //trace start with operation
+        const context = { //build standardized object
+                category: 'api_error', //identify error category
+                operation, //operation description
+                timestamp: new Date().toISOString(), //timestamp for correlation
+                ...details //spread caller-provided details
         };
+        logReturn('createApiErrorContext', context); //trace resulting object
+        return context; //return context for reporting
 }
 
 /**
@@ -49,12 +53,15 @@ function createApiErrorContext(operation, details = {}) {
  * @returns {Object} Standardized error context object
  */
 function createConfigErrorContext(operation, details = {}) {
-        return {
-                category: 'config_error',
+        logStart('createConfigErrorContext', operation); //trace start with operation
+        const context = {
+                category: 'config_error', //categorize configuration errors
                 operation,
-                timestamp: new Date().toISOString(),
+                timestamp: new Date().toISOString(), //timestamp for consistency
                 ...details
         };
+        logReturn('createConfigErrorContext', context); //trace result object
+        return context; //return constructed context
 }
 
 /**
@@ -68,12 +75,15 @@ function createConfigErrorContext(operation, details = {}) {
  * @returns {Object} Standardized error context object
  */
 function createUtilityErrorContext(operation, details = {}) {
-        return {
-                category: 'utility_error',
+        logStart('createUtilityErrorContext', operation); //trace start with operation
+        const context = {
+                category: 'utility_error', //identify generic utility errors
                 operation,
-                timestamp: new Date().toISOString(),
+                timestamp: new Date().toISOString(), //time of occurrence
                 ...details
         };
+        logReturn('createUtilityErrorContext', context); //trace result context
+        return context; //return standardized object
 }
 
 /**
@@ -89,20 +99,24 @@ function createUtilityErrorContext(operation, details = {}) {
  * @param {Object} customDetails - Additional module-specific details
  */
 function reportError(error, message, context = {}, customDetails = {}) {
+        logStart('reportError', message); //trace message being reported
         try {
                 const enrichedContext = {
-                        errorType: error.name || 'Error',
+                        errorType: error.name || 'Error', //standardize error name
                         errorMessage: error.message,
                         stack: error.stack,
                         ...context,
                         ...customDetails
                 };
-                
-                qerrors(error, message, enrichedContext);
+
+                qerrors(error, message, enrichedContext); //delegate to qerrors
+                logReturn('reportError', 'success'); //trace success
+                return true; //indicate handled
         } catch (reportingError) {
-                // Fallback logging if qerrors itself fails
-                console.error('Error reporting failed:', reportingError);
+                console.error('Error reporting failed:', reportingError); //fallback log
                 console.error('Original error:', error);
+                logReturn('reportError', 'failure'); //trace failure
+                return false; //indicate failure
         }
 }
 
@@ -117,12 +131,15 @@ function reportError(error, message, context = {}, customDetails = {}) {
  * @returns {Object} Cache error context object
  */
 function createCacheErrorContext(operation, details = {}) {
-        return {
-                category: 'cache_error',
+        logStart('createCacheErrorContext', operation); //trace cache operation
+        const context = {
+                category: 'cache_error', //label cache-related issue
                 operation,
-                timestamp: new Date().toISOString(),
+                timestamp: new Date().toISOString(), //time for log correlation
                 ...details
         };
+        logReturn('createCacheErrorContext', context); //trace resulting object
+        return context; //return standardized context
 }
 
 /**
@@ -136,12 +153,15 @@ function createCacheErrorContext(operation, details = {}) {
  * @returns {Object} Validation error context object
  */
 function createValidationErrorContext(operation, details = {}) {
-        return {
-                category: 'validation_error',
+        logStart('createValidationErrorContext', operation); //trace start
+        const context = {
+                category: 'validation_error', //category label for validators
                 operation,
-                timestamp: new Date().toISOString(),
+                timestamp: new Date().toISOString(), //timestamp for trace
                 ...details
         };
+        logReturn('createValidationErrorContext', context); //trace object
+        return context; //return structured context
 }
 
 /**
@@ -152,8 +172,11 @@ function createValidationErrorContext(operation, details = {}) {
  * @param {Object} apiDetails - API-specific details (URL, response, etc.)
  */
 function reportApiError(error, operation, apiDetails = {}) {
-        const context = createApiErrorContext(operation, apiDetails);
-        reportError(error, `API Error: ${operation}`, context);
+        logStart('reportApiError', operation); //trace operation
+        const context = createApiErrorContext(operation, apiDetails); //build context
+        const result = reportError(error, `API Error: ${operation}`, context); //delegate reporting
+        logReturn('reportApiError', result); //trace result
+        return result; //return outcome of reportError
 }
 
 /**
@@ -164,8 +187,11 @@ function reportApiError(error, operation, apiDetails = {}) {
  * @param {Object} configDetails - Config-specific details (variables, values, etc.)
  */
 function reportConfigError(error, operation, configDetails = {}) {
-        const context = createConfigErrorContext(operation, configDetails);
-        reportError(error, `Configuration Error: ${operation}`, context);
+        logStart('reportConfigError', operation); //trace operation
+        const context = createConfigErrorContext(operation, configDetails); //build context
+        const result = reportError(error, `Configuration Error: ${operation}`, context); //delegate
+        logReturn('reportConfigError', result); //trace result
+        return result; //propagate
 }
 
 /**
@@ -176,8 +202,11 @@ function reportConfigError(error, operation, configDetails = {}) {
  * @param {Object} validationDetails - Validation-specific details
  */
 function reportValidationError(error, operation, validationDetails = {}) {
-        const context = createValidationErrorContext(operation, validationDetails);
-        reportError(error, `Validation Error: ${operation}`, context);
+        logStart('reportValidationError', operation); //trace operation
+        const context = createValidationErrorContext(operation, validationDetails); //build context
+        const result = reportError(error, `Validation Error: ${operation}`, context); //delegate
+        logReturn('reportValidationError', result); //trace result
+        return result; //return result
 }
 
 /**

--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -116,13 +116,19 @@ async function safeQerrors(error, context, additionalData = {}) { //async to ret
  * @returns {Function} - Wrapped qerrors function with automatic error conversion
  */
 function createCompatibleQerrors() {
-        const qerrors = loadQerrors();
-        
-        return function compatibleQerrors(error, context, additionalData = {}) {
-                // Convert string errors to Error objects for v1.2.3+ compatibility
-                const errorObj = error instanceof Error ? error : new Error(String(error));
-                return qerrors(errorObj, context, additionalData);
+        logStart('createCompatibleQerrors', 'wrapper'); //trace function start
+        const qerrors = loadQerrors(); //load base qerrors implementation
+
+        const compatibleQerrors = function compatibleQerrors(error, context, additionalData = {}) {
+                logStart('compatibleQerrors', context); //trace call context
+                const errorObj = error instanceof Error ? error : new Error(String(error)); //ensure Error instance
+                const result = qerrors(errorObj, context, additionalData); //delegate to loaded qerrors
+                logReturn('compatibleQerrors', result); //trace result for debugging
+                return result; //propagate outcome
         };
+
+        logReturn('createCompatibleQerrors', 'function'); //trace wrapper creation
+        return compatibleQerrors; //return wrapped function
 }
 
 /**
@@ -133,7 +139,10 @@ function createCompatibleQerrors() {
  * calls throughout the codebase.
  */
 module.exports = function() {
-        return createCompatibleQerrors();
+        logStart('defaultExport', 'init'); //trace loader wrapper start
+        const wrapped = createCompatibleQerrors(); //create wrapper function
+        logReturn('defaultExport', 'function'); //trace wrapper created
+        return wrapped; //return new wrapper
 };
 
 // Named exports for enhanced functionality

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -212,6 +212,7 @@ function normalizeNum(num) { //return clamped integer or null for invalid input
 }
 
 function getGoogleURL(query, num) { //accept optional num argument to limit results
+        if (DEBUG) { logStart('getGoogleURL', `${query}, num: ${num}`); } //log start with raw params
         // Apply proper URL encoding for query parameter safety and correctness
         // ENCODING RATIONALE: encodeURIComponent handles critical character transformations:
         // - Spaces become %20 (not + which has different semantics in query strings)
@@ -232,7 +233,12 @@ function getGoogleURL(query, num) { //accept optional num argument to limit resu
         // Normalize num parameter to Google's allowed range 1-10
         // REUSE LOGIC: Delegates clamping to normalizeNum for consistency
         const safeNum = normalizeNum(num); //clamp or null via helper
-        if (safeNum !== null) { return `${base}&num=${safeNum}`; } //append when provided
+        if (safeNum !== null) { //append num parameter when valid
+                const urlWithNum = `${base}&num=${safeNum}`; //construct final URL with num
+                if (DEBUG) { logReturn('getGoogleURL', urlWithNum); } //log computed URL
+                return urlWithNum; //return encoded URL with num
+        }
+        if (DEBUG) { logReturn('getGoogleURL', base); } //log base URL when no num
         return base; //omit num when not provided
 }
 
@@ -452,6 +458,7 @@ function performCacheCleanup() {
  * @throws {Error} If searchTerms is not an array
  */
 async function getTopSearchResults(searchTerms) {
+        if (DEBUG) { logStart('getTopSearchResults', searchTerms); } //log initial array
         // Input validation: ensure we received an array
         // This prevents runtime errors and provides clear feedback about expected input type
         if (!Array.isArray(searchTerms)) {
@@ -471,11 +478,12 @@ async function getTopSearchResults(searchTerms) {
         const validSearchTerms = uniqueTerms.filter(term => typeof term === 'string' && term.trim() !== '');
         
         if (validSearchTerms.length === 0) {
-                logWarn('No valid search terms provided'); //use log utility for warnings
-                return []; // Return empty array rather than failing - graceful degradation
+                logWarn('No valid search terms provided'); //warn about empty input
+                if (DEBUG) { logReturn('getTopSearchResults', '[]'); } //log empty return
+                return []; //graceful degradation for invalid input
         }
-        
-        if (DEBUG) { logStart('getTopSearchResults', validSearchTerms); } //(log start when debug)
+
+        if (DEBUG) { logStart('getTopSearchResults', validSearchTerms); } //log sanitized term list
         
         // Use Promise.all() to execute all searches in parallel for optimal performance
         // PARALLELIZATION STRATEGY: Each search query is independent, allowing concurrent execution


### PR DESCRIPTION
## Summary
- ensure all utility functions log on entry and before exit
- clarify return paths in error context helpers
- add tracing for qerrors loader
- log entry for Google URL builder and top search functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684e28640cc08322b4df64ea36cf6f38