### PR TITLE
Improve test helper docs

### DIFF
--- a/__tests__/utils/consoleSpies.js
+++ b/__tests__/utils/consoleSpies.js
@@ -32,13 +32,11 @@ const { logStart, logReturn } = require('../../lib/logUtils'); //import logging 
  * it reusable across different types of console output testing scenarios.
  */
 function mockConsole(method) {
-  logStart('mockConsole', method); //log start & method
-  // Create Jest spy on console method with silent implementation
-  // jest.spyOn preserves original method for restoration after test
-  // mockImplementation(() => {}) prevents any console output during tests
-  const spy = jest.spyOn(console, method).mockImplementation(() => {}); //create spy with blank impl
-  logReturn('mockConsole', 'spy'); //log returning spy
-  return spy; //return jest spy
+  logStart('mockConsole', method); //log start
+  // jest spy intercepts console without output
+  const spy = jest.spyOn(console, method).mockImplementation(() => {}); //blank spy
+  logReturn('mockConsole', 'spy'); //log return
+  return spy; //return spy
 }
 
 module.exports = { mockConsole }; //export helper


### PR DESCRIPTION
## Summary
- document network mocking and state reset in test setup helpers
- simplify inline comments in console spies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684e286c456483228e48b441f7cdd408