### PR TITLE
Add silent & invalid level logging tests

### DIFF
--- a/__tests__/minLogger.test.js
+++ b/__tests__/minLogger.test.js
@@ -33,4 +33,30 @@ describe('minLogger', () => { // minLogger
     expect(spy).toHaveBeenCalledWith('bad'); //should log
     spy.mockRestore(); //cleanup
   });
+
+  test('silences output when LOG_LEVEL silent', () => { //no output expected
+    process.env.LOG_LEVEL = 'silent'; //activate silent mode
+    const warnSpy = mockConsole('warn'); //spy console.warn
+    const errorSpy = mockConsole('error'); //spy console.error
+    const { logWarn, logError } = require('../lib/minLogger'); //import funcs
+    logWarn('x'); //call warn
+    logError('y'); //call error
+    expect(warnSpy).not.toHaveBeenCalled(); //warn suppressed
+    expect(errorSpy).not.toHaveBeenCalled(); //error suppressed
+    warnSpy.mockRestore(); //restore warn
+    errorSpy.mockRestore(); //restore error
+  });
+
+  test('invalid LOG_LEVEL disables output', () => { //unknown should mute
+    process.env.LOG_LEVEL = 'unknown'; //set invalid level
+    const warnSpy = mockConsole('warn'); //spy console.warn
+    const errorSpy = mockConsole('error'); //spy console.error
+    const { logWarn, logError } = require('../lib/minLogger'); //import funcs
+    logWarn('x'); //call warn
+    logError('y'); //call error
+    expect(warnSpy).not.toHaveBeenCalled(); //warn suppressed
+    expect(errorSpy).not.toHaveBeenCalled(); //error suppressed
+    warnSpy.mockRestore(); //restore warn
+    errorSpy.mockRestore(); //restore error
+  });
 });

--- a/lib/minLogger.js
+++ b/lib/minLogger.js
@@ -49,13 +49,19 @@ function shouldLog(level) {
                 // Convert environment variable to lowercase for case-insensitive matching
                 // Default to 'info' if LOG_LEVEL is not set, providing reasonable verbosity
                 const envLevel = String(process.env.LOG_LEVEL || 'info').toLowerCase(); //get env level
-                
+
+                // Block all logs when LOG_LEVEL is silent
+                if (envLevel === 'silent') { //explicit silent mode check
+                        console.log(`shouldLog LOG_LEVEL silent, returning false`); //trace silent handling
+                        console.log(`shouldLog is returning false`); //trace return value
+                        return false; //no logging when silent
+                }
+
                 // Validate environment level exists in our ranking system
                 if (!(envLevel in levelRank)) {
-                        console.log(`shouldLog invalid env level: ${envLevel}, defaulting to info`);
-                        const result = levelRank[level] <= levelRank['info']; // Fall back to info level
-                        console.log(`shouldLog is returning ${result}`); //trace result
-                        return result;
+                        console.log(`shouldLog invalid env level: ${envLevel}, returning false`); //reject unknown
+                        console.log(`shouldLog is returning false`); //trace return value
+                        return false; //invalid level disables output
                 }
                 
                 // Compare numerical rankings to determine if level is allowed


### PR DESCRIPTION
## Summary
- add tests covering LOG_LEVEL `silent` and invalid value
- block output when LOG_LEVEL is silent or invalid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684e8b8bffb4832281b5adbd5cf85afb