### PR TITLE
Add tests for analysis scripts

### DIFF
--- a/__tests__/memory-growth-analysis.test.js
+++ b/__tests__/memory-growth-analysis.test.js
@@ -1,0 +1,28 @@
+const { mockConsole } = require('./utils/consoleSpies');
+const { saveEnv, restoreEnv, setTestEnv } = require('./utils/testSetup');
+
+describe('memory-growth-analysis script', () => {
+  let savedEnv;
+  let logSpy;
+
+  beforeEach(() => {
+    savedEnv = saveEnv();
+    setTestEnv();
+    process.env.CODEX = 'true';
+    jest.resetModules();
+    logSpy = mockConsole('log');
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    restoreEnv(savedEnv);
+  });
+
+  test('memoryGrowthAnalysis runs and logs completion', async () => {
+    const { memoryGrowthAnalysis } = require('../memory-growth-analysis.js');
+    await expect(memoryGrowthAnalysis()).resolves.toBeUndefined();
+    const logs = logSpy.mock.calls.map(c => c[0]);
+    expect(logs.some(l => l.includes('=== Memory Growth Analysis ==='))).toBe(true); //check start banner
+    expect(logs.some(l => l.includes('=== Memory Analysis Complete ==='))).toBe(true); //check completion banner
+  });
+});

--- a/__tests__/perf-analysis.test.js
+++ b/__tests__/perf-analysis.test.js
@@ -1,0 +1,28 @@
+const { mockConsole } = require('./utils/consoleSpies');
+const { saveEnv, restoreEnv, setTestEnv } = require('./utils/testSetup');
+
+describe('perf-analysis script', () => {
+  let savedEnv;
+  let logSpy;
+
+  beforeEach(() => {
+    savedEnv = saveEnv(); //snapshot env for restoration
+    setTestEnv(); //ensure required env vars present
+    process.env.CODEX = 'true'; //offline mode for deterministic test
+    jest.resetModules(); //reset module cache
+    logSpy = mockConsole('log'); //capture console.log output
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore(); //restore console.log
+    restoreEnv(savedEnv); //restore original env
+  });
+
+  test('cachePerformanceTest runs and logs summary', async () => {
+    const { cachePerformanceTest } = require('../perf-analysis.js');
+    await expect(cachePerformanceTest()).resolves.toBeUndefined();
+    const logs = logSpy.mock.calls.map(c => c[0]);
+    expect(logs.some(l => l.includes('=== Cache Performance Analysis ==='))).toBe(true); //verify start log
+    expect(logs.some(l => l.includes('=== Performance Analysis Complete ==='))).toBe(true); //verify end log
+  });
+});

--- a/__tests__/rate-limit-analysis.test.js
+++ b/__tests__/rate-limit-analysis.test.js
@@ -1,0 +1,28 @@
+const { mockConsole } = require('./utils/consoleSpies');
+const { saveEnv, restoreEnv, setTestEnv } = require('./utils/testSetup');
+
+describe('rate-limit-analysis script', () => {
+  let savedEnv;
+  let logSpy;
+
+  beforeEach(() => {
+    savedEnv = saveEnv();
+    setTestEnv();
+    process.env.CODEX = 'true';
+    jest.resetModules();
+    logSpy = mockConsole('log');
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    restoreEnv(savedEnv);
+  });
+
+  test('rateLimitingAnalysis runs and logs completion', async () => {
+    const { rateLimitingAnalysis } = require('../rate-limit-analysis.js');
+    await expect(rateLimitingAnalysis()).resolves.toBeUndefined();
+    const logs = logSpy.mock.calls.map(c => c[0]);
+    expect(logs.some(l => l.includes('=== Rate Limiting Performance Analysis ==='))).toBe(true); //verify start banner
+    expect(logs.some(l => l.includes('=== Rate Limiting Analysis Complete ==='))).toBe(true); //verify completion banner
+  });
+});

--- a/memory-growth-analysis.js
+++ b/memory-growth-analysis.js
@@ -62,4 +62,6 @@ async function memoryGrowthAnalysis() {
     console.log('\n=== Memory Analysis Complete ===');
 }
 
-memoryGrowthAnalysis().catch(console.error); // start analysis when file executed
+if (require.main === module) { memoryGrowthAnalysis().catch(console.error); } //auto-run only when executed directly
+
+module.exports = { memoryGrowthAnalysis }; //export for test execution

--- a/perf-analysis.js
+++ b/perf-analysis.js
@@ -89,4 +89,6 @@ async function cachePerformanceTest() {
     console.log('=== Performance Analysis Complete ===');
 }
 
-cachePerformanceTest().catch(console.error); // run when executed directly
+if (require.main === module) { cachePerformanceTest().catch(console.error); } //only auto-run when invoked directly
+
+module.exports = { cachePerformanceTest }; //export for test invocation

--- a/rate-limit-analysis.js
+++ b/rate-limit-analysis.js
@@ -67,4 +67,6 @@ async function rateLimitingAnalysis() {
     console.log('\n=== Rate Limiting Analysis Complete ===');
 }
 
-rateLimitingAnalysis().catch(console.error); // execute when script run
+if (require.main === module) { rateLimitingAnalysis().catch(console.error); } //run automatically only when executed directly
+
+module.exports = { rateLimitingAnalysis }; //export for testing


### PR DESCRIPTION
## Summary
- export analysis functions so scripts only auto-execute when run directly
- cover perf-analysis, memory-growth-analysis and rate-limit-analysis with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684f20c7963c8322a913b21cdd682f65