### PR TITLE
Fix CODEX trim comparisons

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -127,7 +127,7 @@ test('handleAxiosError returns false when qerrors throws', async () => { //verif
   spy.mockRestore(); //restore console.error
 }); //end test ensuring failure path
 
-test.each(['True', 'true', 'TRUE', true])('rateLimitedRequest returns mock when CODEX=%s', async val => {
+test.each(['True', 'true', 'TRUE', true, ' true '])('rateLimitedRequest returns mock when CODEX=%s', async val => {
   process.env.CODEX = val; //set CODEX variant to trigger mock response
   ({ mock, scheduleMock, qerrorsMock } = initSearchTest()); //reinit with CODEX set
   const { rateLimitedRequest } = require('../lib/qserp'); //import after env setup
@@ -137,7 +137,7 @@ test.each(['True', 'true', 'TRUE', true])('rateLimitedRequest returns mock when 
   expect(scheduleMock).not.toHaveBeenCalled(); //limiter should be bypassed
   expect(mock.history.get.length).toBe(0); //axios should not receive any request
   delete process.env.CODEX; //clean up env variable for other tests
-}); //test ensures CODEX casings bypass network
+}); //test ensures CODEX variants including whitespace bypass network
 
 test('fetchSearchItems bypasses url build in CODEX mode', async () => { // fetchSearchItems bypasses url build in CODEX mode
   process.env.CODEX = 'true'; //enable codex offline mode

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -150,7 +150,7 @@ async function rateLimitedRequest(url) { //(handle network request with optional
         const safeUrl = sanitizeApiKey(url); //(sanitize api key from url)
         if (DEBUG) { logStart('rateLimitedRequest', safeUrl); } //(avoid key leak with toggle)
 
-        if (String(process.env.CODEX).toLowerCase() === 'true') { //(use case-insensitive true check for codex mock)
+        if (String(process.env.CODEX).trim().toLowerCase() === 'true') { //(ensure whitespace-insensitive true check for codex mock)
                 const mockRes = { data: { items: [] } }; //(return only items array to match offline mode)
                 if (DEBUG) { console.log('rateLimitedRequest using codex mock response'); } //(notify mock path taken when debug)
                 if (DEBUG) { logReturn('rateLimitedRequest', JSON.stringify(mockRes)); } //(mock return log when debug)
@@ -176,7 +176,7 @@ async function rateLimitedRequest(url) { //(handle network request with optional
 
 // Validate required environment variables at module load time
 // Skip when CODEX is "true" so the module can run in offline mode
-if (String(process.env.CODEX).toLowerCase() !== 'true') { //case-insensitive codex check
+if (String(process.env.CODEX).trim().toLowerCase() !== 'true') { //case-insensitive codex check trimming spaces for robust offline toggle
         throwIfMissingEnvVars(REQUIRED_VARS); //only enforce creds when not in codex
 }
 
@@ -386,7 +386,7 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                        }
                }
 
-              if (String(process.env.CODEX).toLowerCase() === 'true') { //(mock path when codex true)
+              if (String(process.env.CODEX).trim().toLowerCase() === 'true') { //(mock path when codex true with whitespace trimming)
                       const items = []; //use static empty array without network call
                       if (MAX_CACHE_SIZE !== 0) { cache.set(cacheKey, items); } //still populate cache for consistency
                       if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log mock return)


### PR DESCRIPTION
## Summary
- handle whitespace in CODEX env checks
- verify CODEX with whitespace enables offline mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fc241ed2083228cd728c949d6372e