### PR TITLE
Improve minLogger log level handling

### DIFF
--- a/__tests__/minLogger.test.js
+++ b/__tests__/minLogger.test.js
@@ -59,4 +59,13 @@ describe('minLogger', () => { // minLogger
     warnSpy.mockRestore(); //restore warn
     errorSpy.mockRestore(); //restore error
   });
+
+  test('console.log not called when silent', () => { //verify trace suppression
+    process.env.LOG_LEVEL = 'silent'; //force silent mode
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {}); //direct spy to avoid helper noise
+    const { logWarn } = require('../lib/minLogger'); //import warn for check
+    logWarn('trace'); //execute warn
+    expect(logSpy).not.toHaveBeenCalled(); //console.log should be muted
+    logSpy.mockRestore(); //cleanup spy
+  });
 });

--- a/lib/minLogger.js
+++ b/lib/minLogger.js
@@ -24,6 +24,12 @@
 // environments than warning messages, following standard logging practices
 const levelRank = { error: 0, warn: 1, info: 2, silent: 3 }; //rank map for levels
 
+// Check if info level logging is allowed for trace messages //rationale: avoid noisy logs when not needed
+function canLogInfo() {
+        const envLvl = String(process.env.LOG_LEVEL || 'info').toLowerCase();
+        return envLvl === 'info'; //only true when env requests info verbosity
+}
+
 /**
  * Determines if a message at the given level should be logged
  * 
@@ -37,42 +43,42 @@ const levelRank = { error: 0, warn: 1, info: 2, silent: 3 }; //rank map for leve
  * if environment variables contain invalid values.
  */
 function shouldLog(level) {
-        console.log(`shouldLog is running with ${level}`); //trace function start
+        if (canLogInfo()) console.log(`shouldLog is running with ${level}`); //trace function start when allowed
         try {
                 // LEVEL VALIDATION FIX: Check if level exists before array access
                 // This prevents undefined comparison when invalid levels are passed
                 if (!(level in levelRank)) {
-                        console.log(`shouldLog invalid level: ${level}, returning false`);
+                        if (canLogInfo()) console.log(`shouldLog invalid level: ${level}, returning false`); //only show when info allowed
                         return false; // Invalid levels are not allowed
                 }
-                
+
                 // Convert environment variable to lowercase for case-insensitive matching
                 // Default to 'info' if LOG_LEVEL is not set, providing reasonable verbosity
                 const envLevel = String(process.env.LOG_LEVEL || 'info').toLowerCase(); //get env level
 
                 // Block all logs when LOG_LEVEL is silent
                 if (envLevel === 'silent') { //explicit silent mode check
-                        console.log(`shouldLog LOG_LEVEL silent, returning false`); //trace silent handling
-                        console.log(`shouldLog is returning false`); //trace return value
+                        if (canLogInfo()) console.log(`shouldLog LOG_LEVEL silent, returning false`); //trace silent handling
+                        if (canLogInfo()) console.log(`shouldLog is returning false`); //trace return value
                         return false; //no logging when silent
                 }
 
                 // Validate environment level exists in our ranking system
                 if (!(envLevel in levelRank)) {
-                        console.log(`shouldLog invalid env level: ${envLevel}, returning false`); //reject unknown
-                        console.log(`shouldLog is returning false`); //trace return value
+                        if (canLogInfo()) console.log(`shouldLog invalid env level: ${envLevel}, returning false`); //reject unknown
+                        if (canLogInfo()) console.log(`shouldLog is returning false`); //trace return value
                         return false; //invalid level disables output
                 }
-                
+
                 // Compare numerical rankings to determine if level is allowed
                 // Lower-numbered (higher priority) levels are allowed in higher-numbered environments
                 const result = levelRank[level] <= levelRank[envLevel]; //determine allowance
-                console.log(`shouldLog is returning ${result}`); //trace result
+                if (canLogInfo()) console.log(`shouldLog is returning ${result}`); //trace result when allowed
                 return result; //return boolean decision
         } catch (err) {
                 // Fail safe: any error in level evaluation blocks logging
                 // This prevents unexpected behavior from malformed environment variables
-                console.log(`shouldLog returning false`); //trace failure path
+                if (canLogInfo()) console.log(`shouldLog returning false`); //trace failure path when allowed
                 return false; //default to no log on error
         }
 }
@@ -93,19 +99,19 @@ function shouldLog(level) {
  * that logging issues never crash the application.
  */
 function logWarn(msg) {
-        console.log(`logWarn is running with ${msg}`); //trace run with message
+        if (shouldLog('info')) console.log(`logWarn is running with ${msg}`); //trace run with message when allowed
         try {
                 // Check if warning level is allowed by current LOG_LEVEL setting
                 // This delegation ensures consistent level handling across all log functions
                 if (shouldLog('warn')) { //respect LOG_LEVEL for warnings
                         console.warn(msg); //emit warning when allowed
                 }
-                console.log(`logWarn is returning true`); //trace successful end
+                if (shouldLog('info')) console.log(`logWarn is returning true`); //trace successful end when allowed
                 return true; //confirm execution
         } catch (err) {
                 // Any error in warning output is contained and reported
                 // This prevents logging failures from disrupting application flow
-                console.log(`logWarn returning false`); //trace failure path
+                if (shouldLog('info')) console.log(`logWarn returning false`); //trace failure path when allowed
                 return false; //indicate failure
         }
 }
@@ -126,19 +132,19 @@ function logWarn(msg) {
  * through the return value.
  */
 function logError(msg) {
-        console.log(`logError is running with ${msg}`); //trace run with message
+        if (shouldLog('info')) console.log(`logError is running with ${msg}`); //trace run with message when allowed
         try {
                 // Check if error level is allowed (should be true unless LOG_LEVEL='silent')
                 // This maintains consistency with the level checking pattern
                 if (shouldLog('error')) { //respect LOG_LEVEL for errors
                         console.error(msg); //emit error when allowed
                 }
-                console.log(`logError is returning true`); //trace successful end
+                if (shouldLog('info')) console.log(`logError is returning true`); //trace successful end when allowed
                 return true; //confirm execution
         } catch (err) {
                 // Handle the rare case where error logging itself fails
                 // This prevents infinite error loops and maintains application stability
-                console.log(`logError returning false`); //trace failure path
+                if (shouldLog('info')) console.log(`logError returning false`); //trace failure path when allowed
                 return false; //indicate failure
         }
 }


### PR DESCRIPTION
## Summary
- gate info-level console tracing behind LOG_LEVEL
- ensure warn and error logs don't produce console output when suppressed
- test console.log remains silent when LOG_LEVEL=silent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fc22e68b08322b2a8f67439ef2cb9