### PR TITLE
Align cache key for default result count

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -162,6 +162,17 @@ describe('qserp module', () => { //group qserp tests
     expect(scheduleMock).not.toHaveBeenCalled(); //no new request expected
   });
 
+  test('undefined num shares cache with explicit 10', async () => { //new unified key test
+    mock.onGet(/Default/).reply(200, { items: [{ link: 'a' }] }); //mock initial request
+    const first = await fetchSearchItems('Default', 10); //populate cache with explicit num 10
+    scheduleMock.mockClear(); //reset counter for second request
+    mock.onGet(/Default/).reply(200, { items: [{ link: 'b' }] }); //different data if fetched again
+    const second = await fetchSearchItems('Default'); //call without num should hit same cache
+    expect(first).toEqual([{ link: 'a' }]); //first response data
+    expect(second).toEqual([{ link: 'a' }]); //should match cached data
+    expect(scheduleMock).not.toHaveBeenCalled(); //no new request expected
+  });
+
   test.each([1, 5, 10])('getGoogleURL includes valid num %i', valid => { //verify clamped url for valid num
     const url = getGoogleURL('Val', valid); //build url with provided num
     expect(url).toBe(`https://customsearch.googleapis.com/customsearch/v1?q=Val&key=key&cx=cx&fields=items(title,snippet,link)&num=${valid}`); //should match num

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -373,9 +373,12 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                // Normalize num once to share between cache key and URL
                const safeNum = normalizeNum(num); //clamp value for consistent behavior
 
+               // Treat undefined num as 10 for cache purposes to unify keys
+               const keyNum = num === undefined ? 10 : safeNum; //use default 10 when no arg
+
                // Generate normalized cache key using centralized helper
                // CONSOLIDATION: Uses createCacheKey helper to ensure consistent normalization
-               const cacheKey = createCacheKey(query, safeNum); //use helper with clamped value
+               const cacheKey = createCacheKey(query, keyNum); //use helper with key-specific num
                let cachedItems;
                if (MAX_CACHE_SIZE !== 0) { //skip cache when disabled
                        cachedItems = cache.get(cacheKey); //lookup existing cache entry with automatic TTL handling


### PR DESCRIPTION
## Summary
- unify caching of default result count so undefined num shares the `:10` entry
- test that undefined `num` uses same cache entry as explicit `10`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fc21cb9988322acb9e3e507b8fb1d