### PR TITLE
Fix CODEX comparison logic and add offline mode test

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -139,6 +139,17 @@ test.each(['True', 'true', 'TRUE', true])('rateLimitedRequest returns mock when 
   delete process.env.CODEX; //clean up env variable for other tests
 }); //test ensures CODEX casings bypass network
 
+test('rateLimitedRequest returns mock when CODEX has spaces', async () => { // verify trimming of CODEX env var
+  process.env.CODEX = ' true '; //value with spaces should still enable mock mode
+  ({ mock, scheduleMock, qerrorsMock } = initSearchTest()); //reinitialize with CODEX set
+  const { rateLimitedRequest } = require('../lib/qserp'); //require after env modifications
+  const res = await rateLimitedRequest('http://codex-space'); //expect mocked response due to trimmed true
+  expect(res).toEqual({ data: { items: [] } }); //mocked structure should match
+  expect(scheduleMock).not.toHaveBeenCalled(); //no rate limiting when offline
+  expect(mock.history.get.length).toBe(0); //axios not executed
+  delete process.env.CODEX; //cleanup env variable
+}); //test ensures CODEX with whitespace bypasses network
+
 test('fetchSearchItems bypasses url build in CODEX mode', async () => { // fetchSearchItems bypasses url build in CODEX mode
   process.env.CODEX = 'true'; //enable codex offline mode
   ({ mock, scheduleMock, qerrorsMock } = initSearchTest()); //reinit with codex flag

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -150,7 +150,7 @@ async function rateLimitedRequest(url) { //(handle network request with optional
         const safeUrl = sanitizeApiKey(url); //(sanitize api key from url)
         if (DEBUG) { logStart('rateLimitedRequest', safeUrl); } //(avoid key leak with toggle)
 
-        if (String(process.env.CODEX).toLowerCase() === 'true') { //(use case-insensitive true check for codex mock)
+        if (String(process.env.CODEX).trim().toLowerCase() === 'true') { //(use trimmed, case-insensitive true check for codex mock)
                 const mockRes = { data: { items: [] } }; //(return only items array to match offline mode)
                 if (DEBUG) { console.log('rateLimitedRequest using codex mock response'); } //(notify mock path taken when debug)
                 if (DEBUG) { logReturn('rateLimitedRequest', JSON.stringify(mockRes)); } //(mock return log when debug)
@@ -176,7 +176,7 @@ async function rateLimitedRequest(url) { //(handle network request with optional
 
 // Validate required environment variables at module load time
 // Skip when CODEX is "true" so the module can run in offline mode
-if (String(process.env.CODEX).toLowerCase() !== 'true') { //case-insensitive codex check
+if (String(process.env.CODEX).trim().toLowerCase() !== 'true') { //case-insensitive codex check with trimming
         throwIfMissingEnvVars(REQUIRED_VARS); //only enforce creds when not in codex
 }
 
@@ -386,7 +386,7 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                        }
                }
 
-              if (String(process.env.CODEX).toLowerCase() === 'true') { //(mock path when codex true)
+              if (String(process.env.CODEX).trim().toLowerCase() === 'true') { //(mock path when codex true using trimmed case-insensitive check)
                       const items = []; //use static empty array without network call
                       if (MAX_CACHE_SIZE !== 0) { cache.set(cacheKey, items); } //still populate cache for consistency
                       if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log mock return)


### PR DESCRIPTION
## Summary
- ensure CODEX env checks use trimmed string comparison
- test that whitespace around CODEX values still enables offline mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fc2334c5083229c80f15476050a30