### PR TITLE
Fix API key sanitization on error

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -169,7 +169,7 @@ test('sanitizeApiKey replaces all matches', () => { //ensure global replacement
   expect(res).toBe('start [redacted] middle [redacted] end'); //expect both replaced
 });
 
-test('sanitizeApiKey returns input and logs when regex fails', () => { //trigger catch branch
+test('sanitizeApiKey returns sanitized string when regex fails', () => { //trigger catch branch
   const savedDebug = process.env.DEBUG; //preserve debug flag
   process.env.DEBUG = 'true'; //enable debug logging
   jest.resetModules(); //reload module to capture debug flag
@@ -177,11 +177,11 @@ test('sanitizeApiKey returns input and logs when regex fails', () => { //trigger
   const logSpy = require('./utils/consoleSpies').mockConsole('log'); //spy console.log
   const originalEncode = global.encodeURIComponent; //capture original function
   global.encodeURIComponent = jest.fn(() => { throw new Error('boom'); }); //force failure
-  const result = sanitizeApiKey('text'); //execute with failing encode
-  expect(result).toBe('text'); //should return input unchanged
+  const result = sanitizeApiKey('text key text'); //execute with failing encode and key present
+  expect(result).toBe('text [redacted] text'); //should return sanitized value
   const logs = logSpy.mock.calls.map(c => c[0]); //captured log messages
-  expect(logs).toContain('sanitizeApiKey is running with text'); //logs contain start message
-  expect(logs).toContain('sanitizeApiKey is returning text'); //logs contain end message
+  expect(logs).toContain('sanitizeApiKey is running with text [redacted] text'); //logs contain sanitized start message
+  expect(logs).toContain('sanitizeApiKey is returning text [redacted] text'); //logs contain sanitized end message
   global.encodeURIComponent = originalEncode; //restore encodeURIComponent
   logSpy.mockRestore(); //cleanup spy
   if (savedDebug !== undefined) { process.env.DEBUG = savedDebug; } else { delete process.env.DEBUG; } //restore env

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -92,9 +92,10 @@ function sanitizeApiKey(text) { //replace raw or encoded api key in text
                 if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //log sanitized argument before modification
                 result = sanitizedInput; //use sanitized version as result
         } catch (err) {
-                sanitizedInput = text; //fallback sanitized log on error
-                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //log fallback input when debug
-                result = text; //return unmodified text on error
+                const currentKey = process.env.GOOGLE_API_KEY || defaultApiKey; //re-read key to sanitize fallback
+                sanitizedInput = typeof text === 'string' && currentKey ? text.split(currentKey).join('[redacted]') : text; //basic replace when regex fails
+                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //log sanitized fallback when debug
+                result = sanitizedInput; //return sanitized fallback
         }
         if (DEBUG) { console.log(`sanitizeApiKey is returning ${result}`); } //log sanitized output when debug
         return result; //return sanitized value


### PR DESCRIPTION
## Summary
- sanitize the API key even if regex creation fails
- adjust the failing-path test to expect sanitized output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fc23a1fd88322bbe9d19bbd7ae2da