### PR TITLE
Consolidate optional env checks

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -182,8 +182,7 @@ if (String(process.env.CODEX).toLowerCase() !== 'true') { //case-insensitive cod
 
 // Warn about optional environment variables that enhance functionality
 // OPENAI_TOKEN is used by qerrors for enhanced error analysis but isn't strictly required
-warnIfMissingEnvVars(['OPENAI_TOKEN'], OPENAI_WARN_MSG); //specific warning for qerrors
-warnIfMissingEnvVars(['GOOGLE_REFERER']); //generic warning for optional referer header
+warnIfMissingEnvVars(OPTIONAL_VARS, OPENAI_WARN_MSG); //single check for optional vars with token message
 
 /**
  * Generates a Google Custom Search API URL with proper encoding


### PR DESCRIPTION
## Summary
- check optional env vars in one call
- ensure OPENAI_TOKEN warning constant used
- test optional env var list usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fc22036d08322af56a03bafb31c00