### PR TITLE
Use safeQerrors in utils

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,25 +1,34 @@
 // Summary: utils.test.js validates module behavior and edge cases
 const { createQerrorsMock } = require('./utils/testSetup'); //import qerrors mock helper
 
-const { safeRun } = require('../lib/utils'); //import function under test
-
 describe('safeRun', () => { //group safeRun tests
   test('returns result when function succeeds', () => { //success branch
-    const qerrors = createQerrorsMock(); //reset qerrors mock
-    const fn = jest.fn(() => 5); //mock function returning value
-    const res = safeRun('testFn', fn, 0, { a: 1 }); //execute safeRun
-    expect(res).toBe(5); //should return fn result
-    expect(fn).toHaveBeenCalled(); //function called
-    expect(qerrors).not.toHaveBeenCalled(); //qerrors unused
+    jest.isolateModules(() => {
+      const qerrorsLoader = require('../lib/qerrorsLoader'); //load loader for spy setup
+      const safeSpy = jest.spyOn(qerrorsLoader, 'safeQerrors'); //spy on safeQerrors
+      const { safeRun } = require('../lib/utils'); //load function under test
+      const qerrors = createQerrorsMock(); //reset qerrors mock after module load
+      const fn = jest.fn(() => 5); //mock function returning value
+      const res = safeRun('testFn', fn, 0, { a: 1 }); //execute safeRun
+      expect(res).toBe(5); //should return fn result
+      expect(fn).toHaveBeenCalled(); //function called
+      expect(safeSpy).not.toHaveBeenCalled(); //safeQerrors unused
+      expect(qerrors).not.toHaveBeenCalled(); //qerrors unused
+    });
   });
 
   test('returns default value and logs error when function throws', () => { //failure branch
-    const qerrors = createQerrorsMock(); //reset qerrors mock
-    const fn = jest.fn(() => { throw new Error('fail'); }); //mock throwing fn
-    const res = safeRun('badFn', fn, 1, { b: 2 }); //execute safeRun
-    expect(res).toBe(1); //should return fallback
-    expect(fn).toHaveBeenCalled(); //function called
-    expect(qerrors).toHaveBeenCalledWith(expect.any(Error), 'badFn error', { b: 2 }); //qerrors invoked
+    jest.isolateModules(() => {
+      const qerrorsLoader = require('../lib/qerrorsLoader'); //load loader for spy
+      const safeSpy = jest.spyOn(qerrorsLoader, 'safeQerrors'); //spy on wrapper
+      const { safeRun } = require('../lib/utils'); //load function under test
+      const qerrors = createQerrorsMock(); //reset qerrors mock after load
+      const fn = jest.fn(() => { throw new Error('fail'); }); //mock throwing fn
+      const res = safeRun('badFn', fn, 1, { b: 2 }); //execute safeRun
+      expect(res).toBe(1); //should return fallback
+      expect(fn).toHaveBeenCalled(); //function called
+      expect(safeSpy).toHaveBeenCalledWith(expect.any(Error), 'badFn error', { b: 2 }); //wrapper invoked
+    });
   });
 
   test('does not log when DEBUG false', () => { //verify debug gating

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,6 +12,7 @@
  */
 
 const qerrors = require('./qerrorsLoader')(); //import qerrors via loader to support varied export styles
+const { safeQerrors } = require('./qerrorsLoader'); //import safe wrapper to handle qerrors failures
 const { logStart, logReturn } = require('./logUtils'); // Import standardized logging utilities
 const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility
 const DEBUG = getDebugFlag(); //determine current debug state
@@ -65,10 +66,10 @@ function safeRun(fnName, fn, defaultVal, context) {
                 
         } catch (error) {
                 // Handle any error that occurs during function execution
-                // ERROR REPORTING STRATEGY: Use qerrors for structured error logging with full context
-                // This provides consistent error reporting across the application and enables
-                // better debugging by including the operation name and any relevant context data
-                qerrors(error, `${fnName} error`, context);
+                // ERROR REPORTING STRATEGY: Use safeQerrors for resilient logging without crashing
+                // This ensures error reporting failures are handled gracefully while providing
+                // structured data with the operation name and context
+                safeQerrors(error, `${fnName} error`, context); //safeQerrors resolves promise internally
                 
                 // Log the fallback value being returned for debugging visibility
                 // FALLBACK TRANSPARENCY: Makes it clear in logs when fallback behavior is triggered,


### PR DESCRIPTION
## Summary
- import `safeQerrors` in `lib/utils.js`
- use `safeQerrors` for resilient logging
- update `utils.test.js` to expect `safeQerrors` calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685034b4e1288322a0fde2288c37d03e