### PR TITLE
Use safeQerrors in envUtils

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -1,5 +1,6 @@
 // Summary: envUtils.test.js validates module behavior and edge cases
 let qerrors; //holds mock loaded after reset (setup in testSetup)
+let safeQerrors; //mocked safeQerrors reference for assertions
 const { saveEnv, restoreEnv } = require('./utils/testSetup'); //import env helpers //(new utilities)
 const { mockConsole } = require('./utils/consoleSpies'); //added console spy helper
 
@@ -11,7 +12,16 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
   beforeEach(() => { //prepare each test //(reset env and mocks)
     savedEnv = saveEnv(); //capture current env //(using util)
     jest.resetModules(); //reload modules so env vars re-evaluated //(ensures clean require)
-    qerrors = require('qerrors'); //re-acquire mock after module reset
+    jest.doMock('../lib/qerrorsLoader', () => { //mock qerrors loader per test
+      const mockFn = jest.fn(); //placeholder qerrors function
+      const loader = jest.fn(() => mockFn); //callable default export
+      loader.safeQerrors = jest.fn(); //spy for resilience wrapper
+      loader.default = loader; //support .default usage
+      return loader; //export loader function
+    });
+    const loader = require('../lib/qerrorsLoader'); //get mocked loader
+    qerrors = loader(); //qerrors function used by utils
+    safeQerrors = loader.safeQerrors; //capture safeQerrors spy for assertions
     const minLogger = require('../lib/minLogger'); //import logger after reset
     warnSpy = jest.spyOn(minLogger, 'logWarn').mockImplementation(() => {}); //spy warn
     errorSpy = jest.spyOn(minLogger, 'logError').mockImplementation(() => {}); //spy error
@@ -22,6 +32,7 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     warnSpy.mockRestore(); //restore logWarn spy //(remove spy)
     errorSpy.mockRestore(); //restore logError spy //(remove spy)
     jest.clearAllMocks(); //clear any mock usage //(reset mock counts)
+    jest.dontMock('../lib/qerrorsLoader'); //remove loader mock to avoid cross-suite impact
   });
 
   test('handles all variables present', () => { //verify no missing vars //(first case)
@@ -34,6 +45,7 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     expect(warnSpy).not.toHaveBeenCalled(); //warn not called //(check)
     expect(errorSpy).not.toHaveBeenCalled(); //error not called //(check)
     expect(qerrors).not.toHaveBeenCalled(); //qerrors not called //(check)
+    expect(safeQerrors).not.toHaveBeenCalled(); //safeQerrors not called //(check)
   });
 
   test('handles some variables missing', () => { //verify missing logic //(second case)
@@ -45,7 +57,8 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     expect(warnIfMissingEnvVars(['A', 'B'], 'warn')).toBe(false); //should warn //(assert)
     expect(warnSpy).toHaveBeenCalledWith('warn'); //warn called with message //(check)
     expect(errorSpy).toHaveBeenCalledWith('Missing required environment variables: B'); //error logged //(check)
-    expect(qerrors).toHaveBeenCalledTimes(1); //qerrors invoked once //(check)
+    expect(qerrors).not.toHaveBeenCalled(); //qerrors not used directly //(check)
+    expect(safeQerrors).toHaveBeenCalledTimes(1); //safeQerrors invoked once //(check)
   });
 
   test('handles undefined variable array', () => { //verify undefined input //(third case)
@@ -56,6 +69,7 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     expect(warnSpy).not.toHaveBeenCalled(); //warn not called //(check)
     expect(errorSpy).not.toHaveBeenCalled(); //error not called //(check)
     expect(qerrors).toHaveBeenCalledTimes(3); //qerrors invoked three times //(check)
+    expect(safeQerrors).not.toHaveBeenCalled(); //safeQerrors not called //(check)
   });
 
   test('does not log when DEBUG false', () => { //verify debug gating

--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -10,8 +10,8 @@
  * This approach improves developer experience and reduces troubleshooting time.
  */
 
-// Import qerrors using shared loader
-const qerrors = require('./qerrorsLoader')(); //retrieve qerrors function via loader
+// Import safeQerrors using shared loader
+const { safeQerrors } = require('./qerrorsLoader'); //retrieve safe wrapper for qerrors
 const { logStart, logReturn } = require('./logUtils'); //import standardized log utilities
 const { safeRun } = require('./utils'); //import safeRun utility for common error handling
 const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility
@@ -67,10 +67,10 @@ function throwIfMissingEnvVars(varArr) {
                
                const err = new Error(errorMessage);
                
-               // Report through qerrors with context for structured error tracking
+               // Report through safeQerrors with context for structured error tracking
                // CONTEXT INCLUSION: varArr provides debugging context about which variables
                // were being validated when the error occurred
-               qerrors(err, 'throwIfMissingEnvVars error', { varArr });
+               safeQerrors(err, 'throwIfMissingEnvVars error', { varArr }); //use wrapped error reporter for resilience
                
                throw err; // Fail fast - required variables are non-negotiable
        }


### PR DESCRIPTION
## Summary
- switch env utils to use `safeQerrors`
- mock `safeQerrors` in env util tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685034b8d1f48322bf4b97bc38ee03a0