### PR TITLE
Prevent mock caching in CODEX mode

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -394,13 +394,13 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                }
 
 
-              if (String(process.env.CODEX).trim().toLowerCase() === 'true') { //(mock path when codex true using trimmed case-insensitive check)
+             if (String(process.env.CODEX).trim().toLowerCase() === 'true') { //(mock path when codex true using trimmed case-insensitive check)
 
-                      const items = []; //use static empty array without network call
-                      if (MAX_CACHE_SIZE !== 0) { cache.set(cacheKey, items); } //still populate cache for consistency
-                      if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log mock return)
-                      return items; //return mock array directly without calling rateLimitedRequest
-              }
+                     const items = []; //use static empty array without network call
+                     // skip cache set so CODEX calls do not pollute cache //(omit caching when offline)
+                     if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log mock return)
+                     return items; //return mock array directly without calling rateLimitedRequest
+             }
 
               const url = getGoogleURL(query, safeNum); //(build search url with clamped num)
 


### PR DESCRIPTION
## Summary
- stop caching items in CODEX branch so offline requests don't populate the cache
- verify CODEX calls don't fill cache and subsequent live calls fetch data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685034ac076c8322873e0107970757fc