### PR TITLE
Clarify cache disablement option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ These variables enhance functionality but are not required:
 - `OPENAI_TOKEN` – Used by the `qerrors` dependency for enhanced error analysis and logging
 - `CODEX` – When set to any case-insensitive `true` value, enables offline mode with mocked responses
 - `LOG_LEVEL` – Controls `warn` and `error` output (`info` by default)
-- `QSERP_MAX_CACHE_SIZE` – Maximum cache entries (default: 1000, range: 10-50000) for memory management
+- `QSERP_MAX_CACHE_SIZE` – Maximum cache entries (default: 1000, `0` disables caching; range: 10-50000 when enabled) for memory management
 - `GOOGLE_REFERER` – Adds a Referer header to requests when set
 
 ## Usage
@@ -222,7 +222,8 @@ The module implements intelligent LRU caching with automatic memory management t
 ### Memory Management
 Configure cache behavior with the `QSERP_MAX_CACHE_SIZE` environment variable:
 - **Default**: 1000 entries (~10MB typical usage)
-- **Range**: 10-50000 entries (automatically constrained for security)
+- **Disable**: Set to `0` to turn off caching completely
+- **Range**: 10-50000 entries when caching is enabled (automatically constrained for security)
 - **Eviction**: Automatic LRU eviction when size limit reached
 
 ### Cache Examples


### PR DESCRIPTION
## Summary
- clarify README about setting `QSERP_MAX_CACHE_SIZE` to `0`
- document how `QSERP_MAX_CACHE_SIZE` disables caching in Memory Management section

## Testing
- `npm test` *(fails: envUtils.test.js: expect(qerrors).toHaveBeenCalledTimes(3))*

------
https://chatgpt.com/codex/tasks/task_b_685054525f548322b12f6712b7161102