### PR TITLE
Fix cache key default for invalid num values

### DIFF
--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -10,8 +10,9 @@
  * This approach improves developer experience and reduces troubleshooting time.
  */
 
-// Import safeQerrors using shared loader
-const { safeQerrors } = require('./qerrorsLoader'); //retrieve safe wrapper for qerrors
+// Import qerrors and its safe wrapper for flexible error reporting
+const qerrors = require('./qerrorsLoader')(); //direct qerrors function for explicit logging
+const { safeQerrors } = require('./qerrorsLoader'); //safe wrapper still used by utils
 const { logStart, logReturn } = require('./logUtils'); //import standardized log utilities
 const { safeRun } = require('./utils'); //import safeRun utility for common error handling
 const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility
@@ -30,6 +31,12 @@ const DEBUG = getDebugFlag(); //determine current debug state
  */
 function getMissingEnvVars(varArr) {
        if (DEBUG) { logStart('getMissingEnvVars', varArr); } //log start only when debug enabled
+
+       if (!Array.isArray(varArr)) { //bypass safeRun when input invalid
+               qerrors(new Error('Invalid varArr'), 'getMissingEnvVars error', { varArr }); //direct log for type issues
+               if (DEBUG) { logReturn('getMissingEnvVars', []); } //debug early return value
+               return []; //consistent fallback for invalid input
+       }
 
        const missingArr = safeRun('getMissingEnvVars', () =>
                varArr.filter(name => !process.env[name]), [], { varArr }); //(filter safely)

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -375,10 +375,10 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
         try {
 
                // Normalize num once to share between cache key and URL
-               const safeNum = normalizeNum(num); //clamp value for consistent behavior
+               const safeNum = normalizeNum(num); //clamp or null when non numeric
 
-               // Treat undefined num as 10 for cache purposes to unify keys
-               const keyNum = num === undefined ? 10 : safeNum; //use default 10 when no arg
+               // Treat null or undefined safeNum as default 10 to unify keys for non numeric values
+               const keyNum = safeNum === null ? 10 : safeNum; //use default 10 when invalid or missing
 
                // Generate normalized cache key using centralized helper
                // CONSOLIDATION: Uses createCacheKey helper to ensure consistent normalization


### PR DESCRIPTION
## Summary
- ensure fetchSearchItems treats non-numeric num as default `10`
- document the new behavior inline
- log invalid `varArr` in envUtils for consistent qerrors usage
- test non-numeric `num` caching

## Testing
- `npm test --silent --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_68505441e99883229ca3a0ecc6835e3b