### PR TITLE
Update fetchSearchItems num docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Fetches raw Google Custom Search API items for a query. Optional `num` limits th
 
 **Parameters:**
 - `query` (string): The search query (must be non-empty)
-- `num` (number, optional): Maximum number of items to return (range 1-10; values outside this range are clamped)
+- `num` (number, optional): Maximum number of items to return (range 1-10; values outside this range are clamped). Non-numeric values use the default of 10
 
 **Returns:**
 - `Promise<Array>`: Raw items array from Google API or empty array on error


### PR DESCRIPTION
## Summary
- clarify how non-numeric `num` defaults to 10 in README

## Testing
- `npm test` *(fails: envUtils.test.js handles undefined variable array)*

------
https://chatgpt.com/codex/tasks/task_b_68505448b2b08322826dbeb2e9a6e12d