### PR TITLE
Update cache size docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ These variables enhance functionality but are not required:
 - `OPENAI_TOKEN` – Used by the `qerrors` dependency for enhanced error analysis and logging
 - `CODEX` – When set to any case-insensitive `true` value, enables offline mode with mocked responses
 - `LOG_LEVEL` – Controls `warn` and `error` output (`info` by default)
-- `QSERP_MAX_CACHE_SIZE` – Maximum cache entries (default: 1000, range: 10-50000) for memory management
+- `QSERP_MAX_CACHE_SIZE` – Maximum cache entries (default: 1000, range: 0-50000 (0 disables caching)) for memory management
 - `GOOGLE_REFERER` – Adds a Referer header to requests when set
 
 ## Usage
@@ -222,7 +222,7 @@ The module implements intelligent LRU caching with automatic memory management t
 ### Memory Management
 Configure cache behavior with the `QSERP_MAX_CACHE_SIZE` environment variable:
 - **Default**: 1000 entries (~10MB typical usage)
-- **Range**: 10-50000 entries (automatically constrained for security)
+- **Range**: 0-50000 entries (0 disables caching, automatically constrained for security)
 - **Eviction**: Automatic LRU eviction when size limit reached
 
 ### Cache Examples

--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -68,8 +68,8 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     expect(warnIfMissingEnvVars(undefined, 'warn')).toBe(true); //should not warn //(assert)
     expect(warnSpy).not.toHaveBeenCalled(); //warn not called //(check)
     expect(errorSpy).not.toHaveBeenCalled(); //error not called //(check)
-    expect(qerrors).toHaveBeenCalledTimes(3); //qerrors invoked three times //(check)
-    expect(safeQerrors).not.toHaveBeenCalled(); //safeQerrors not called //(check)
+    expect(qerrors).not.toHaveBeenCalled(); //qerrors should not be called //(check)
+    expect(safeQerrors).toHaveBeenCalledTimes(3); //safeQerrors invoked three times //(check)
   });
 
   test('does not log when DEBUG false', () => { //verify debug gating


### PR DESCRIPTION
## Summary
- clarify QSERP_MAX_CACHE_SIZE range with note on cache disabling
- fix envUtils tests expecting qerrors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68505433b0ac8322970b9b3b2b866451