### PR TITLE
Fix error stack preservation and update tests

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -68,8 +68,8 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     expect(warnIfMissingEnvVars(undefined, 'warn')).toBe(true); //should not warn //(assert)
     expect(warnSpy).not.toHaveBeenCalled(); //warn not called //(check)
     expect(errorSpy).not.toHaveBeenCalled(); //error not called //(check)
-    expect(qerrors).toHaveBeenCalledTimes(3); //qerrors invoked three times //(check)
-    expect(safeQerrors).not.toHaveBeenCalled(); //safeQerrors not called //(check)
+    expect(qerrors).not.toHaveBeenCalled(); //qerrors not used directly //(check)
+    expect(safeQerrors).toHaveBeenCalledTimes(3); //safeQerrors invoked three times //(check)
   });
 
   test('does not log when DEBUG false', () => { //verify debug gating

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -113,6 +113,7 @@ test('handleAxiosError passes sanitized error to qerrors', async () => { //verif
   expect(arg).not.toBe(err); //should be copied
   expect(arg.message).toBe('bad [redacted]=[redacted]'); //message sanitized
   expect(arg.config.url).toBe('http://x?[redacted]=[redacted]'); //url sanitized
+  expect(arg.stack).toBe(err.stack); //stack should be retained on sanitized copy
 });
 
 test('handleAxiosError returns false when qerrors throws', async () => { //verify fallback on qerrors failure

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -267,6 +267,7 @@ async function handleAxiosError(error, contextMsg) { //async to await qerrors re
 
                 const sanitized = Object.assign(new Error(), errObj); //clone properties into new Error object
                 sanitized.message = sanitizeApiKey(errObj.message); //overwrite message with sanitized value
+                if (errObj.stack) { sanitized.stack = errObj.stack; } //retain original stack when provided
                 if (errObj && errObj.config && errObj.config.url) { //check for config before copy
                         sanitized.config = { ...errObj.config, url: sanitizeApiKey(errObj.config.url) }; //sanitize url field
                 }


### PR DESCRIPTION
## Summary
- keep original stack on sanitized errors
- verify stack property passed to qerrors
- fix env utils test to check safeQerrors usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850543639e88322b8715dde2f4ad76c