### PR TITLE
Update env warning calls

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -4,7 +4,7 @@ const { initSearchTest, resetMocks } = require('./utils/testSetup'); //use new h
 const { mock, scheduleMock, qerrorsMock } = initSearchTest(); //initialize env and mocks
 
 const { googleSearch, getTopSearchResults, fetchSearchItems, clearCache, getGoogleURL } = require('../lib/qserp'); //load functions under test from library
-const { OPENAI_WARN_MSG, OPTIONAL_VARS } = require('../lib/constants'); //import warning message constant and optional list
+const { OPENAI_WARN_MSG } = require('../lib/constants'); //import warning message constant
 
 describe('qserp module', () => { //group qserp tests
   beforeEach(() => { //reset mocks before each test
@@ -106,7 +106,8 @@ describe('qserp module', () => { //group qserp tests
     mockLocal.onGet(/Two/).reply(200, { items: [{ link: '2' }] }); //mock second term
     const urls = await topSearch(['One', 'Two']); //run function expecting warning
     expect(urls).toEqual(['1', '2']); //ensure urls returned correctly
-    expect(warnEnvSpy).toHaveBeenCalledWith(OPTIONAL_VARS, OPENAI_WARN_MSG); //ensure optional vars list used
+    expect(warnEnvSpy).toHaveBeenNthCalledWith(1, ['OPENAI_TOKEN'], OPENAI_WARN_MSG); //first call validates token
+    expect(warnEnvSpy).toHaveBeenNthCalledWith(2, ['GOOGLE_REFERER']); //second call validates referer
     expect(warnSpy).toHaveBeenCalledWith(OPENAI_WARN_MSG); //warning should reference constant
     warnEnvSpy.mockRestore(); //restore env utils spy
     warnSpy.mockRestore(); //restore console.warn spy

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -186,8 +186,10 @@ if (String(process.env.CODEX).trim().toLowerCase() !== 'true') { //case-insensit
 }
 
 // Warn about optional environment variables that enhance functionality
-// OPENAI_TOKEN is used by qerrors for enhanced error analysis but isn't strictly required
-warnIfMissingEnvVars(OPTIONAL_VARS, OPENAI_WARN_MSG); //single check for optional vars with token message
+// OPENAI_TOKEN is used by qerrors for enhanced error analysis
+warnIfMissingEnvVars(['OPENAI_TOKEN'], OPENAI_WARN_MSG); //custom message for token warning
+// GOOGLE_REFERER improves search analytics but is optional
+warnIfMissingEnvVars(['GOOGLE_REFERER']); //default warning without custom message
 
 /**
  * Generates a Google Custom Search API URL with proper encoding


### PR DESCRIPTION
## Summary
- warn separately for missing OPENAI_TOKEN and GOOGLE_REFERER
- expect two env warnings in qserp tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68506cb9f45883228167095d2468f634