### PR TITLE
Fix optional env var warnings

### DIFF
--- a/__tests__/constants.test.js
+++ b/__tests__/constants.test.js
@@ -1,8 +1,7 @@
 // Summary: constants.test.js validates module behavior and edge cases
-const { REQUIRED_VARS, OPTIONAL_VARS, OPENAI_WARN_MSG } = require('../lib/constants'); //import constants to test their values
+const { REQUIRED_VARS, OPTIONAL_VARS } = require('../lib/constants'); //import constants to test their values
 
 test('constants arrays have expected entries', () => { //verify exports
   expect(REQUIRED_VARS).toEqual(['GOOGLE_API_KEY', 'GOOGLE_CX']); //should match required list
   expect(OPTIONAL_VARS).toEqual(['OPENAI_TOKEN', 'GOOGLE_REFERER']); //should match optional list
-  expect(OPENAI_WARN_MSG).toBe('OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.'); //should match warning text
 });

--- a/__tests__/integrationCombined.test.js
+++ b/__tests__/integrationCombined.test.js
@@ -5,7 +5,6 @@ const { mockConsole } = require('./utils/consoleSpies'); //added console spy hel
 let { mock, scheduleMock, qerrorsMock } = initSearchTest(); //init environment and mocks
 
 const { googleSearch, getTopSearchResults } = require('../lib/qserp'); //load functions under test
-const { OPENAI_WARN_MSG } = require('../lib/constants'); //import warning constant
 
 describe('integration googleSearch and getTopSearchResults', () => { //describe block
   beforeEach(() => { //reset mocks
@@ -47,7 +46,8 @@ describe('integration googleSearch and getTopSearchResults', () => { //describe 
     mock.onGet(/Warn/).reply(200, { items: [{ title: 't', snippet: 's', link: 'l' }] }); //mock search success
     const res = await tokenlessSearch('Warn'); //perform search with mocked data
     expect(res).toEqual([{ title: 't', snippet: 's', link: 'l' }]); //ensure results returned
-    expect(warnSpy).toHaveBeenCalledWith(OPENAI_WARN_MSG); //check warning message
+    const expectedWarning = 'Warning: Optional environment variables missing: OPENAI_TOKEN. Some features may not work as expected.'; //dynamic warning text
+    expect(warnSpy).toHaveBeenCalledWith(expectedWarning); //check warning message
     warnSpy.mockRestore(); //restore console.warn
     process.env.OPENAI_TOKEN = saveToken; //restore original token
   });

--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -4,7 +4,7 @@ const { initSearchTest, resetMocks } = require('./utils/testSetup'); //use new h
 const { mock, scheduleMock, qerrorsMock } = initSearchTest(); //initialize env and mocks
 
 const { googleSearch, getTopSearchResults, fetchSearchItems, clearCache, getGoogleURL } = require('../lib/qserp'); //load functions under test from library
-const { OPENAI_WARN_MSG, OPTIONAL_VARS } = require('../lib/constants'); //import warning message constant and optional list
+const { OPTIONAL_VARS } = require('../lib/constants'); //import optional list for env warning checks
 
 describe('qserp module', () => { //group qserp tests
   beforeEach(() => { //reset mocks before each test
@@ -106,8 +106,9 @@ describe('qserp module', () => { //group qserp tests
     mockLocal.onGet(/Two/).reply(200, { items: [{ link: '2' }] }); //mock second term
     const urls = await topSearch(['One', 'Two']); //run function expecting warning
     expect(urls).toEqual(['1', '2']); //ensure urls returned correctly
-    expect(warnEnvSpy).toHaveBeenCalledWith(OPTIONAL_VARS, OPENAI_WARN_MSG); //ensure optional vars list used
-    expect(warnSpy).toHaveBeenCalledWith(OPENAI_WARN_MSG); //warning should reference constant
+    const expectedWarning = 'Warning: Optional environment variables missing: OPENAI_TOKEN. Some features may not work as expected.'; //dynamic message based on missing var
+    expect(warnEnvSpy).toHaveBeenCalledWith(OPTIONAL_VARS); //ensure optional vars list used without custom message
+    expect(warnSpy).toHaveBeenCalledWith(expectedWarning); //warning should include missing token
     warnEnvSpy.mockRestore(); //restore env utils spy
     warnSpy.mockRestore(); //restore console.warn spy
     process.env.OPENAI_TOKEN = tokenSave; //restore original token

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -51,12 +51,6 @@ const REQUIRED_VARS = ['GOOGLE_API_KEY', 'GOOGLE_CX'];
  */
 const OPTIONAL_VARS = ['OPENAI_TOKEN', 'GOOGLE_REFERER']; //referer header optional for custom analytics
 
-/**
- * Warning message when OPENAI_TOKEN is missing
- *
- * Centralized string so tests and runtime use the same value
- */
-const OPENAI_WARN_MSG = 'OPENAI_TOKEN environment variable is not set. This is required by the qerrors dependency for error logging.'; //(added constant)
 
 /**
  * Module exports
@@ -70,6 +64,5 @@ const OPENAI_WARN_MSG = 'OPENAI_TOKEN environment variable is not set. This is r
  */
 module.exports = {
         REQUIRED_VARS,  // Critical variables that must be present
-        OPTIONAL_VARS,  // Enhancing variables that improve functionality but aren't essential
-        OPENAI_WARN_MSG // Warning text when optional token missing
+        OPTIONAL_VARS   // Enhancing variables that improve functionality but aren't essential
 };

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -104,7 +104,7 @@ function sanitizeApiKey(text) { //replace raw or encoded api key in text
 // Import utility functions for environment variable validation
 // These utilities centralize env var handling to avoid repetitive validation code
 const { throwIfMissingEnvVars, warnIfMissingEnvVars } = require('./envUtils'); //env validation utilities //(trim unused)
-const { REQUIRED_VARS, OPTIONAL_VARS, OPENAI_WARN_MSG } = require('./constants'); // Centralized env var definitions with warning message
+const { REQUIRED_VARS, OPTIONAL_VARS } = require('./constants'); //centralized env var names (no message constant)
 
 /**
  * Rate limiter configuration using Bottleneck
@@ -187,7 +187,7 @@ if (String(process.env.CODEX).trim().toLowerCase() !== 'true') { //case-insensit
 
 // Warn about optional environment variables that enhance functionality
 // OPENAI_TOKEN is used by qerrors for enhanced error analysis but isn't strictly required
-warnIfMissingEnvVars(OPTIONAL_VARS, OPENAI_WARN_MSG); //single check for optional vars with token message
+warnIfMissingEnvVars(OPTIONAL_VARS); //use default message listing missing optional vars dynamically
 
 /**
  * Generates a Google Custom Search API URL with proper encoding


### PR DESCRIPTION
## Summary
- remove `OPENAI_WARN_MSG` constant
- warn about whichever optional env vars are missing
- update tests for new dynamic message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68506cac31dc8322a85ffd46ec35a9d1