### PR TITLE
Make safeRun asynchronous

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -2,43 +2,49 @@
 const { createQerrorsMock } = require('./utils/testSetup'); //import qerrors mock helper
 
 describe('safeRun', () => { //group safeRun tests
-  test('returns result when function succeeds', () => { //success branch
+  test('returns result when function succeeds', async () => { //success branch
+    let safeRun;
+    let safeSpy;
+    let qerrors;
     jest.isolateModules(() => {
       const qerrorsLoader = require('../lib/qerrorsLoader'); //load loader for spy setup
-      const safeSpy = jest.spyOn(qerrorsLoader, 'safeQerrors'); //spy on safeQerrors
-      const { safeRun } = require('../lib/utils'); //load function under test
-      const qerrors = createQerrorsMock(); //reset qerrors mock after module load
-      const fn = jest.fn(() => 5); //mock function returning value
-      const res = safeRun('testFn', fn, 0, { a: 1 }); //execute safeRun
-      expect(res).toBe(5); //should return fn result
-      expect(fn).toHaveBeenCalled(); //function called
-      expect(safeSpy).not.toHaveBeenCalled(); //safeQerrors unused
-      expect(qerrors).not.toHaveBeenCalled(); //qerrors unused
+      safeSpy = jest.spyOn(qerrorsLoader, 'safeQerrors'); //spy on safeQerrors
+      safeRun = require('../lib/utils').safeRun; //load function under test
+      qerrors = createQerrorsMock(); //reset qerrors mock after module load
     });
+    const fn = jest.fn(() => 5); //mock function returning value
+    const res = await safeRun('testFn', fn, 0, { a: 1 }); //execute safeRun asynchronously
+    expect(res).toBe(5); //should return fn result
+    expect(fn).toHaveBeenCalled(); //function called
+    expect(safeSpy).not.toHaveBeenCalled(); //safeQerrors unused
+    expect(qerrors).not.toHaveBeenCalled(); //qerrors unused
   });
 
-  test('returns default value and logs error when function throws', () => { //failure branch
+  test('returns default value and logs error when function throws', async () => { //failure branch
+    let safeRun;
+    let safeSpy;
+    let qerrors;
     jest.isolateModules(() => {
       const qerrorsLoader = require('../lib/qerrorsLoader'); //load loader for spy
-      const safeSpy = jest.spyOn(qerrorsLoader, 'safeQerrors'); //spy on wrapper
-      const { safeRun } = require('../lib/utils'); //load function under test
-      const qerrors = createQerrorsMock(); //reset qerrors mock after load
-      const fn = jest.fn(() => { throw new Error('fail'); }); //mock throwing fn
-      const res = safeRun('badFn', fn, 1, { b: 2 }); //execute safeRun
-      expect(res).toBe(1); //should return fallback
-      expect(fn).toHaveBeenCalled(); //function called
-      expect(safeSpy).toHaveBeenCalledWith(expect.any(Error), 'badFn error', { b: 2 }); //wrapper invoked
+      safeSpy = jest.spyOn(qerrorsLoader, 'safeQerrors'); //spy on wrapper
+      safeRun = require('../lib/utils').safeRun; //load function under test
+      qerrors = createQerrorsMock(); //reset qerrors mock after load
     });
+    const fn = jest.fn(() => { throw new Error('fail'); }); //mock throwing fn
+    const res = await safeRun('badFn', fn, 1, { b: 2 }); //execute safeRun asynchronously
+    expect(res).toBe(1); //should return fallback
+    expect(fn).toHaveBeenCalled(); //function called
+    expect(safeSpy).toHaveBeenCalledWith(expect.any(Error), 'badFn error', { b: 2 }); //wrapper invoked
   });
 
-  test('does not log when DEBUG false', () => { //verify debug gating
+  test('does not log when DEBUG false', async () => { //verify debug gating
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {}); //spy on console.log
     delete process.env.DEBUG; //ensure debug flag unset
     jest.resetModules(); //reload modules to pick up env change
     const { safeRun } = require('../lib/utils'); //re-import after reset
     const fn = jest.fn(() => 1); //simple function
     const before = logSpy.mock.calls.length; //record initial log count
-    safeRun('noLog', fn, 0); //call expecting no logs
+    await safeRun('noLog', fn, 0); //call expecting no logs
     expect(logSpy.mock.calls.length).toBe(before); //no additional logs when debug off
     logSpy.mockRestore(); //restore console.log
   });

--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -13,10 +13,20 @@
 // Import safeQerrors using shared loader
 const { safeQerrors } = require('./qerrorsLoader'); //retrieve safe wrapper for qerrors
 const { logStart, logReturn } = require('./logUtils'); //import standardized log utilities
-const { safeRun } = require('./utils'); //import safeRun utility for common error handling
+// safeRun now returns a promise; env utils implement sync logic internally
 const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility
 const { logWarn, logError } = require('./minLogger'); //minimal logging for warn/error
 const DEBUG = getDebugFlag(); //determine current debug state
+
+// Helper replicates old safeRun behavior synchronously for env checks
+function calcMissing(varArr) {
+       try { //attempt to filter normally without upfront checks to mimic prior behavior
+               return varArr.filter(name => !process.env[name]);
+       } catch (err) {
+               safeQerrors(err, 'getMissingEnvVars error', { varArr }); //report filter failure
+               return []; //fallback to empty array on error
+       }
+}
 
 /**
  * Identifies which environment variables from a given list are missing
@@ -31,8 +41,7 @@ const DEBUG = getDebugFlag(); //determine current debug state
 function getMissingEnvVars(varArr) {
        if (DEBUG) { logStart('getMissingEnvVars', varArr); } //log start only when debug enabled
 
-       const missingArr = safeRun('getMissingEnvVars', () =>
-               varArr.filter(name => !process.env[name]), [], { varArr }); //(filter safely)
+       const missingArr = calcMissing(varArr); //sync filter with error handling
 
        if (DEBUG) { logReturn('getMissingEnvVars', missingArr); } //log result only when debug enabled
        return missingArr; //return filtered array or fallback
@@ -52,7 +61,7 @@ function getMissingEnvVars(varArr) {
 function throwIfMissingEnvVars(varArr) {
        if (DEBUG) { logStart('throwIfMissingEnvVars', varArr); } //log start only when debug enabled
 
-       const missingEnvVars = getMissingEnvVars(varArr); //reuse detection utility
+       const missingEnvVars = calcMissing(varArr); //sync detection with safe error handling
 
        if (missingEnvVars.length > 0) {
                // Construct comprehensive error message listing all missing variables
@@ -93,7 +102,7 @@ function throwIfMissingEnvVars(varArr) {
 function warnIfMissingEnvVars(varArr, customMessage = '') {
        if (DEBUG) { logStart('warnIfMissingEnvVars', varArr); } //log start only when debug enabled
 
-       const missingEnvVars = getMissingEnvVars(varArr); //reuse detection utility
+       const missingEnvVars = calcMissing(varArr); //sync detection with safe error handling
 
        if (missingEnvVars.length > 0) {
                // Use custom message if provided, otherwise generate default warning

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,10 +40,10 @@ const DEBUG = getDebugFlag(); //determine current debug state
  * @param {Object} context - Additional context for error reporting (optional)
  * @returns {any} Result of fn() if successful, defaultVal if fn() throws an error
  */
-function safeRun(fnName, fn, defaultVal, context) {
+async function safeRun(fnName, fn, defaultVal, context) { //async to return promise
         // Log the start of safe execution with context for debugging
         // SAFE JSON FIX: Use try-catch around JSON.stringify to handle circular references
-        if (DEBUG) { 
+        if (DEBUG) {
                 try {
                         logStart('safeRun', JSON.stringify({ fnName, context }));
                 } catch (jsonError) {
@@ -51,32 +51,31 @@ function safeRun(fnName, fn, defaultVal, context) {
                         logStart('safeRun', `${fnName} with context: ${String(context)}`);
                 }
         }
-        
+
         try {
                 // Execute the provided function within controlled error boundary
                 // PARAMETER DESIGN: Function should be parameterless to simplify error handling.
                 // Any required parameters should be bound using .bind() or arrow functions beforehand.
-                // This design prevents parameter-related errors and makes the safe execution pattern consistent.
-                const result = fn();
-                
+                // Await result so callers can use both sync and async functions transparently
+                const result = await fn(); //await result for uniform promise return
+
                 // Log successful execution result for debugging
                 // This helps track when operations succeed vs when they fall back
                 if (DEBUG) { logReturn('safeRun', result); } //log success when debug enabled
                 return result; // Return the successful result
-                
+
         } catch (error) {
                 // Handle any error that occurs during function execution
                 // ERROR REPORTING STRATEGY: Use safeQerrors for resilient logging without crashing
-                // This ensures error reporting failures are handled gracefully while providing
-                // structured data with the operation name and context
-                safeQerrors(error, `${fnName} error`, context); //safeQerrors resolves promise internally
-                
+                // Await the reporting to ensure completion before resolving
+                await safeQerrors(error, `${fnName} error`, context); //await async reporter
+
                 // Log the fallback value being returned for debugging visibility
                 // FALLBACK TRANSPARENCY: Makes it clear in logs when fallback behavior is triggered,
                 // helping developers understand when operations fail vs succeed normally.
                 // This is crucial for distinguishing between normal operation and degraded functionality.
                 if (DEBUG) { logReturn('safeRun', defaultVal); }
-                
+
                 // Return the fallback value for graceful degradation
                 // GRACEFUL DEGRADATION: Rather than crashing, return a sensible default that allows
                 // the application to continue operating with reduced functionality


### PR DESCRIPTION
## Summary
- support async operations in `safeRun`
- keep env utils synchronous by replicating old logic
- update safeRun tests for Promise-based behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68506cafceec8322989e36fdc3c144e2