### PR TITLE
Fix sanitizeApiKey to keep parameter names

### DIFF
--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -80,25 +80,34 @@ const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
 const { logStart, logReturn } = require('./logUtils'); //standardized logging utilities
 const { logWarn, logError } = require('./minLogger'); //minimal log utility for warn/error
 
-function sanitizeApiKey(text) { //replace raw or encoded api key in text
+function sanitizeApiKey(text) { //mask api key values without altering param names
         let result; //final sanitized value holder
         let sanitizedInput; //input sanitized only for logging
         try {
-                const currentKey = process.env.GOOGLE_API_KEY || defaultApiKey; //read current key to handle runtime changes
-                const keyRegex = currentKey ? new RegExp(currentKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g') : null; //create regex for raw key each call
-                const encKeyRegex = currentKey ? new RegExp(encodeURIComponent(currentKey).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi') : null; //create regex for encoded key each call
-                sanitizedInput = typeof text === 'string' && keyRegex ? text.replace(keyRegex, '[redacted]') : text; //replace raw key
-                sanitizedInput = typeof sanitizedInput === 'string' && encKeyRegex ? sanitizedInput.replace(encKeyRegex, '[redacted]') : sanitizedInput; //replace encoded key
-                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //log sanitized argument before modification
+                const currentKey = process.env.GOOGLE_API_KEY || defaultApiKey; //read current key each call
+                const escKey = currentKey ? currentKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape regex metachars
+                const rawParamRegex = currentKey ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //match key after '=' to keep name
+                const encParamRegex = currentKey ? new RegExp(`([?&][^=&]*%3D)${encodeURIComponent(currentKey)}`, 'gi') : null; //match encoded '=' forms
+                const plainRegex = currentKey ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //match standalone key not followed by '='
+                sanitizedInput = typeof text === 'string' ? text : text; //ensure string handling
+                if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //replace param value only
+                if (encParamRegex) sanitizedInput = sanitizedInput.replace(encParamRegex, '$1[redacted]'); //replace encoded param value
+                if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //replace standalone key
+                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //trace sanitized input
                 result = sanitizedInput; //use sanitized version as result
         } catch (err) {
-                const currentKey = process.env.GOOGLE_API_KEY || defaultApiKey; //re-read key to sanitize fallback
-                sanitizedInput = typeof text === 'string' && currentKey ? text.split(currentKey).join('[redacted]') : text; //basic replace when regex fails
-                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //log sanitized fallback when debug
+                const currentKey = process.env.GOOGLE_API_KEY || defaultApiKey; //re-read on failure
+                const escKey = currentKey ? currentKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape for fallback regex
+                const rawParamRegex = currentKey ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //fallback param regex
+                const plainRegex = currentKey ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //fallback plain regex
+                sanitizedInput = typeof text === 'string' ? text : text; //retain original type
+                if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //mask value portion
+                if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //mask plain occurrences
+                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //trace fallback
                 result = sanitizedInput; //return sanitized fallback
         }
-        if (DEBUG) { console.log(`sanitizeApiKey is returning ${result}`); } //log sanitized output when debug
-        return result; //return sanitized value
+        if (DEBUG) { console.log(`sanitizeApiKey is returning ${result}`); } //final sanitized result log
+        return result; //return sanitized string
 }
 
 // Import utility functions for environment variable validation


### PR DESCRIPTION
## Summary
- refine `sanitizeApiKey` so only the API key value is masked
- update tests for new sanitization logic
- add regression test for partial-word handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850731da2b88322ae89b91dd628416b