### PR TITLE
Trim LOG_LEVEL whitespace for logging

### DIFF
--- a/__tests__/minLogger.test.js
+++ b/__tests__/minLogger.test.js
@@ -68,4 +68,26 @@ describe('minLogger', () => { // minLogger
     expect(logSpy).not.toHaveBeenCalled(); //console.log should be muted
     logSpy.mockRestore(); //cleanup spy
   });
+
+  test('trims trailing space on warn level', () => { //ensure whitespace is ignored
+    process.env.LOG_LEVEL = 'warn '; //set level with trailing space
+    const spy = mockConsole('warn'); //spy on console.warn
+    const { logWarn } = require('../lib/minLogger'); //import function
+    logWarn('b'); //call logger
+    expect(spy).toHaveBeenCalledWith('b'); //should log despite space
+    spy.mockRestore(); //cleanup spy
+  });
+
+  test('trims spaces on error level', () => { //error level should still suppress warn
+    process.env.LOG_LEVEL = ' error '; //level with spaces around
+    const warnSpy = mockConsole('warn'); //spy console.warn
+    const errorSpy = mockConsole('error'); //spy console.error
+    const { logWarn, logError } = require('../lib/minLogger'); //import funcs
+    logWarn('x'); //call warn
+    logError('y'); //call error
+    expect(warnSpy).not.toHaveBeenCalled(); //warn suppressed due to level
+    expect(errorSpy).toHaveBeenCalledWith('y'); //error logged despite spaces
+    warnSpy.mockRestore(); //cleanup warn spy
+    errorSpy.mockRestore(); //cleanup error spy
+  });
 });

--- a/lib/minLogger.js
+++ b/lib/minLogger.js
@@ -26,7 +26,7 @@ const levelRank = { error: 0, warn: 1, info: 2, silent: 3 }; //rank map for leve
 
 // Check if info level logging is allowed for trace messages //rationale: avoid noisy logs when not needed
 function canLogInfo() {
-        const envLvl = String(process.env.LOG_LEVEL || 'info').toLowerCase();
+        const envLvl = String(process.env.LOG_LEVEL || 'info').trim().toLowerCase(); //normalize env var trimming spaces
         return envLvl === 'info'; //only true when env requests info verbosity
 }
 
@@ -54,7 +54,7 @@ function shouldLog(level) {
 
                 // Convert environment variable to lowercase for case-insensitive matching
                 // Default to 'info' if LOG_LEVEL is not set, providing reasonable verbosity
-                const envLevel = String(process.env.LOG_LEVEL || 'info').toLowerCase(); //get env level
+                const envLevel = String(process.env.LOG_LEVEL || 'info').trim().toLowerCase(); //get env level and remove spaces
 
                 // Block all logs when LOG_LEVEL is silent
                 if (envLevel === 'silent') { //explicit silent mode check


### PR DESCRIPTION
## Summary
- ensure LOG_LEVEL values ignore extra whitespace
- add tests for LOG_LEVEL strings with spaces

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_685073180b848322a817723fa78a2d08