### PR TITLE
Wrap cache helper logs in DEBUG check

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -300,4 +300,42 @@ describe('qserp module', () => { //group qserp tests
     logSpy.mockRestore(); //cleanup
     if (savedDebug !== undefined) { process.env.DEBUG = savedDebug; } else { delete process.env.DEBUG; } //restore debug
   });
+
+  test('cache helpers log when DEBUG true', () => { //verify logging occurs
+    const savedDebug = process.env.DEBUG; //preserve env var
+    process.env.DEBUG = 'true'; //enable debug output
+    jest.resetModules(); //reload module for debug flag
+    const logSpy = require('./utils/consoleSpies').mockConsole('log'); //spy on log
+    const { setTestEnv } = require('./utils/testSetup'); //ensure required env
+    setTestEnv(); //setup env vars
+    logSpy.mockClear(); //discard setup logs
+    const { clearCache, performCacheCleanup } = require('../lib/qserp'); //load functions
+    logSpy.mockClear(); //ignore module init logs
+    clearCache(); //invoke cache clear
+    performCacheCleanup(); //invoke cleanup
+    const messages = logSpy.mock.calls.map(c => c[0]); //gather log messages
+    expect(messages).toContain('clearCache is running with 0'); //start logged
+    expect(messages).toContain('clearCache returning true'); //end logged
+    expect(messages).toContain('performCacheCleanup is running with 0'); //start logged
+    expect(messages).toContain('performCacheCleanup returning false'); //end logged when none purged
+    logSpy.mockRestore(); //cleanup spy
+    if (savedDebug !== undefined) { process.env.DEBUG = savedDebug; } else { delete process.env.DEBUG; } //restore env
+  });
+
+  test('cache helpers silent when DEBUG false', () => { //verify no logs
+    const savedDebug = process.env.DEBUG; //preserve env var
+    process.env.DEBUG = 'false'; //disable debug output
+    jest.resetModules(); //reload module for debug flag
+    const logSpy = require('./utils/consoleSpies').mockConsole('log'); //spy on log
+    const { setTestEnv } = require('./utils/testSetup'); //ensure env
+    setTestEnv(); //set variables
+    logSpy.mockClear(); //ignore setup logs
+    const { clearCache, performCacheCleanup } = require('../lib/qserp'); //load fresh module
+    logSpy.mockClear(); //ignore module init logs
+    clearCache(); //call clearCache
+    performCacheCleanup(); //call cleanup
+    expect(logSpy).not.toHaveBeenCalled(); //no logs expected
+    logSpy.mockRestore(); //cleanup
+    if (savedDebug !== undefined) { process.env.DEBUG = savedDebug; } else { delete process.env.DEBUG; } //restore env
+  });
 });

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -432,9 +432,9 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
  * @returns {boolean} true when cache cleared
  */
 function clearCache() {
-        logStart('clearCache', cache.size); //(log current cache size)
+        if (DEBUG) { logStart('clearCache', cache.size); } //only log when debugging
         cache.clear(); //(remove all cached entries)
-        logReturn('clearCache', true); //(log completion)
+        if (DEBUG) { logReturn('clearCache', true); } //log success when debugging
         return true; //(confirm cleared)
 }
 
@@ -448,9 +448,9 @@ function clearCache() {
  * @returns {boolean} true if any stale entries were removed
  */
 function performCacheCleanup() {
-        logStart('performCacheCleanup', cache.size); //(log size before purge)
+        if (DEBUG) { logStart('performCacheCleanup', cache.size); } //trace start when debugging
         const removed = cache.purgeStale(); //(evict expired entries if present)
-        logReturn('performCacheCleanup', removed); //(log whether anything purged)
+        if (DEBUG) { logReturn('performCacheCleanup', removed); } //trace result when debugging
         return removed; //(propagate purge result)
 }
 


### PR DESCRIPTION
## Summary
- conditionally log in `clearCache` and `performCacheCleanup`
- test logging for cache helpers when `DEBUG` is enabled or disabled

## Testing
- `CI=true npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_685072d0caa48322af1b7beb0a162469