### PR TITLE
Use env helpers in tests

### DIFF
--- a/__tests__/envValidator.test.js
+++ b/__tests__/envValidator.test.js
@@ -7,6 +7,7 @@
  */
 
 const { parseIntWithBounds, parseBooleanVar, parseStringVar, validateEnvVar } = require('../lib/envValidator');
+const { saveEnv, restoreEnv } = require('./utils/testSetup'); //env helpers for isolation
 
 // Mock dependencies to isolate envValidator functionality
 jest.mock('../lib/debugUtils');
@@ -14,17 +15,15 @@ jest.mock('../lib/debugUtils');
 const { debugEntry, debugExit } = require('../lib/debugUtils');
 
 describe('envValidator', () => { // envValidator
-    let originalEnv;
+    let savedEnv; //snapshot for env restoration
 
     beforeEach(() => {
-        // Save original environment variables
-        originalEnv = { ...process.env };
-        jest.clearAllMocks();
+        savedEnv = saveEnv(); //capture environment state
+        jest.clearAllMocks(); //reset mocks
     });
 
     afterEach(() => {
-        // Restore original environment variables
-        process.env = originalEnv;
+        restoreEnv(savedEnv); //restore environment state
     });
 
     describe('parseIntWithBounds', () => { // parseIntWithBounds

--- a/__tests__/getDebugFlag.test.js
+++ b/__tests__/getDebugFlag.test.js
@@ -7,21 +7,20 @@
  */
 
 const { getDebugFlag } = require('../lib/getDebugFlag');
+const { saveEnv, restoreEnv } = require('./utils/testSetup'); //import env helpers for isolation
 
 describe('getDebugFlag', () => { // getDebugFlag
-    let originalEnv;
-    let consoleSpy;
+    let savedEnv; //holds snapshot of process.env for restoration
+    let consoleSpy; //console spy for log assertions
 
     beforeEach(() => {
-        // Save original environment and mock console
-        originalEnv = { ...process.env };
-        consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        savedEnv = saveEnv(); //capture env using shared util
+        consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {}); //stub console.log
     });
 
     afterEach(() => {
-        // Restore original environment and console
-        process.env = originalEnv;
-        consoleSpy.mockRestore();
+        restoreEnv(savedEnv); //reset env after test using util
+        consoleSpy.mockRestore(); //restore console
     });
 
     describe('case-insensitive true detection', () => { // case-insensitive true detection

--- a/__tests__/parseStringVar.test.js
+++ b/__tests__/parseStringVar.test.js
@@ -7,6 +7,7 @@
  */
 
 const { parseStringVar, validateEnvVar } = require('../lib/envValidator');
+const { saveEnv, restoreEnv } = require('./utils/testSetup'); //import env helpers
 
 // Mock dependencies to isolate functionality
 jest.mock('../lib/debugUtils');
@@ -14,15 +15,15 @@ jest.mock('../lib/debugUtils');
 const { debugEntry, debugExit } = require('../lib/debugUtils');
 
 describe('parseStringVar', () => { // parseStringVar
-    let originalEnv;
+    let savedEnv; //snapshot of environment for restoration
 
     beforeEach(() => {
-        originalEnv = { ...process.env };
-        jest.clearAllMocks();
+        savedEnv = saveEnv(); //capture current env using util
+        jest.clearAllMocks(); //reset mocks
     });
 
     afterEach(() => {
-        process.env = originalEnv;
+        restoreEnv(savedEnv); //restore env after each test
     });
 
     describe('basic string parsing', () => { // basic string parsing
@@ -133,15 +134,15 @@ describe('parseStringVar', () => { // parseStringVar
 });
 
 describe('validateEnvVar', () => { // validateEnvVar
-    let originalEnv;
+    let savedEnv; //env snapshot for restore
 
     beforeEach(() => {
-        originalEnv = { ...process.env };
-        jest.clearAllMocks();
+        savedEnv = saveEnv(); //store current env
+        jest.clearAllMocks(); //reset mocks per test
     });
 
     afterEach(() => {
-        process.env = originalEnv;
+        restoreEnv(savedEnv); //restore environment
     });
 
     describe('required variable validation', () => { // required variable validation


### PR DESCRIPTION
## Summary
- update tests to use shared saveEnv/restoreEnv helpers
- remove direct environment assignments after each run

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685072f51fdc8322bc11c72d09fe79ef