### PR TITLE
Validate env var array in calcMissing

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -73,6 +73,18 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     expect(safeQerrors).toHaveBeenCalledTimes(3); //safeQerrors invoked three times //(check)
   });
 
+  test('handles non-array variable type', () => { //verify invalid object input //(new case)
+    const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('../lib/envUtils'); //require utils fresh //(ensure env captured)
+    const badVal = { foo: 'bar' }; //object passed instead of array //(setup)
+    expect(getMissingEnvVars(badVal)).toEqual([]); //should return empty array //(assert)
+    expect(throwIfMissingEnvVars(badVal)).toEqual([]); //should not throw //(assert)
+    expect(warnIfMissingEnvVars(badVal, 'warn')).toBe(true); //should not warn //(assert)
+    expect(warnSpy).not.toHaveBeenCalled(); //warn not called //(check)
+    expect(errorSpy).not.toHaveBeenCalled(); //error not called //(check)
+    expect(qerrors).not.toHaveBeenCalled(); //qerrors not used directly //(check)
+    expect(safeQerrors).toHaveBeenCalledTimes(3); //safeQerrors invoked three times //(check)
+  });
+
   test('does not log when DEBUG false', () => { //verify debug gating
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {}); //spy on console.log
     delete process.env.DEBUG; //ensure debug flag unset

--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -20,10 +20,21 @@ const DEBUG = getDebugFlag(); //determine current debug state
 
 // Helper replicates old safeRun behavior synchronously for env checks
 function calcMissing(varArr) {
+       if (DEBUG) { logStart('calcMissing', varArr); } //trace call for debugging
+
+       if (!Array.isArray(varArr)) { //validate input type before filter
+               safeQerrors(new Error('varArr must be array'), 'calcMissing invalid varArr', { varArr }); //report invalid value
+               if (DEBUG) { logReturn('calcMissing', []); } //trace fallback result
+               return []; //graceful fallback when parameter invalid
+       }
+
        try { //attempt to filter normally without upfront checks to mimic prior behavior
-               return varArr.filter(name => !process.env[name]);
+               const result = varArr.filter(name => !process.env[name]);
+               if (DEBUG) { logReturn('calcMissing', result); } //trace filtered list
+               return result; //return computed array
        } catch (err) {
                safeQerrors(err, 'getMissingEnvVars error', { varArr }); //report filter failure
+               if (DEBUG) { logReturn('calcMissing', []); } //trace fallback result
                return []; //fallback to empty array on error
        }
 }


### PR DESCRIPTION
## Summary
- validate `varArr` is an array in `calcMissing`
- report invalid values through `safeQerrors`
- add regression test for non-array input to env utils

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68508bf809a0832291741b2888282bba