### PR TITLE
Handle non-string input in API key sanitization

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -205,6 +205,19 @@ test('sanitizeApiKey returns sanitized string when regex fails', () => { //trigg
   if (savedDebug !== undefined) { process.env.DEBUG = savedDebug; } else { delete process.env.DEBUG; } //restore env
 });
 
+test('sanitizeApiKey handles object input via toString', () => { //non-string object sanitization
+  const { sanitizeApiKey } = require('../lib/qserp'); //load helper after env setup
+  const obj = { toString() { return 'obj key=key'; } }; //object with key in toString
+  const res = sanitizeApiKey(obj); //invoke with object
+  expect(res).toBe('obj key=[redacted]'); //object string sanitized
+});
+
+test('sanitizeApiKey handles number input without error', () => { //numeric input sanitization
+  const { sanitizeApiKey } = require('../lib/qserp'); //load helper
+  const res = sanitizeApiKey(123); //invoke with number
+  expect(res).toBe('123'); //result coerced to string
+});
+
 test('normalizeNum returns null when parseInt throws', () => { //validate catch path
   const { normalizeNum } = require('../lib/qserp'); //load function under test
   const parseSpy = jest.spyOn(global, 'parseInt').mockImplementation(() => { throw new Error('bad'); }); //mock parseInt throw

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -80,6 +80,15 @@ const qerrors = require('./qerrorsLoader')(); //load qerrors via shared loader
 const { logStart, logReturn } = require('./logUtils'); //standardized logging utilities
 const { logWarn, logError } = require('./minLogger'); //minimal log utility for warn/error
 
+/**
+ * Replaces occurrences of the API key with a redacted token.
+ *
+ * The input value is coerced to a string before any replacement so callers can
+ * pass numbers or objects without risking TypeError from String.replace.
+ *
+ * @param {any} text - Value potentially containing the API key
+ * @returns {string} sanitized string with key values masked
+ */
 function sanitizeApiKey(text) { //mask api key values without altering param names
         let result; //final sanitized value holder
         let sanitizedInput; //input sanitized only for logging
@@ -89,7 +98,7 @@ function sanitizeApiKey(text) { //mask api key values without altering param nam
                 const rawParamRegex = currentKey ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //match key after '=' to keep name
                 const encParamRegex = currentKey ? new RegExp(`([?&][^=&]*%3D)${encodeURIComponent(currentKey)}`, 'gi') : null; //match encoded '=' forms
                 const plainRegex = currentKey ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //match standalone key not followed by '='
-                sanitizedInput = typeof text === 'string' ? text : text; //ensure string handling
+                sanitizedInput = String(text); //convert to string to avoid TypeError on non-string input
                 if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //replace param value only
                 if (encParamRegex) sanitizedInput = sanitizedInput.replace(encParamRegex, '$1[redacted]'); //replace encoded param value
                 if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //replace standalone key
@@ -100,7 +109,7 @@ function sanitizeApiKey(text) { //mask api key values without altering param nam
                 const escKey = currentKey ? currentKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape for fallback regex
                 const rawParamRegex = currentKey ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //fallback param regex
                 const plainRegex = currentKey ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //fallback plain regex
-                sanitizedInput = typeof text === 'string' ? text : text; //retain original type
+                sanitizedInput = String(text); //coerce again to string for safe replace
                 if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //mask value portion
                 if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //mask plain occurrences
                 if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //trace fallback


### PR DESCRIPTION
## Summary
- coerce input to string in `sanitizeApiKey`
- cover objects/numbers in unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68508bbe157c8322873c68b8f4a70297