### PR TITLE
Fix sanitizeApiKey handling of non-string args

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -301,6 +301,15 @@ describe('qserp module', () => { //group qserp tests
     if (savedDebug !== undefined) { process.env.DEBUG = savedDebug; } else { delete process.env.DEBUG; } //restore debug
   });
 
+  test('sanitizeApiKey handles non-string input', () => { //verify object input converted
+    jest.resetModules(); //reload module to ensure fresh state
+    const { setTestEnv } = require('./utils/testSetup'); //setup env for key
+    setTestEnv(); //apply environment variables
+    const { sanitizeApiKey } = require('../lib/qserp'); //require sanitized function
+    const result = sanitizeApiKey(new Error('pre key post')); //pass Error object
+    expect(result).toBe('Error: pre [redacted] post'); //should sanitize within stringified error
+  });
+
   test('cache helpers log when DEBUG true', () => { //verify logging occurs
     const savedDebug = process.env.DEBUG; //preserve env var
     process.env.DEBUG = 'true'; //enable debug output

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -89,7 +89,7 @@ function sanitizeApiKey(text) { //mask api key values without altering param nam
                 const rawParamRegex = currentKey ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //match key after '=' to keep name
                 const encParamRegex = currentKey ? new RegExp(`([?&][^=&]*%3D)${encodeURIComponent(currentKey)}`, 'gi') : null; //match encoded '=' forms
                 const plainRegex = currentKey ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //match standalone key not followed by '='
-                sanitizedInput = typeof text === 'string' ? text : text; //ensure string handling
+                sanitizedInput = String(text); //normalize to string for safe replace calls
                 if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //replace param value only
                 if (encParamRegex) sanitizedInput = sanitizedInput.replace(encParamRegex, '$1[redacted]'); //replace encoded param value
                 if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //replace standalone key
@@ -100,7 +100,7 @@ function sanitizeApiKey(text) { //mask api key values without altering param nam
                 const escKey = currentKey ? currentKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape for fallback regex
                 const rawParamRegex = currentKey ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //fallback param regex
                 const plainRegex = currentKey ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //fallback plain regex
-                sanitizedInput = typeof text === 'string' ? text : text; //retain original type
+                sanitizedInput = String(text); //convert to string so replace never fails
                 if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //mask value portion
                 if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //mask plain occurrences
                 if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //trace fallback


### PR DESCRIPTION
## Summary
- sanitizeApiKey now converts input with `String()` so `.replace()` is safe
- add unit test for sanitizeApiKey using an Error object argument

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68508bc741d483229e1e0842f68c1276