### PR TITLE
Add input guard to calcMissing

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -73,6 +73,17 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     expect(safeQerrors).toHaveBeenCalledTimes(3); //safeQerrors invoked three times //(check)
   });
 
+  test('handles non-array variable input', () => { //verify input type guarding //added new test
+    const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('../lib/envUtils'); //require utils fresh
+    expect(getMissingEnvVars('A')).toEqual([]); //returns empty when input string //added assertion
+    expect(throwIfMissingEnvVars('A')).toEqual([]); //returns empty without throw //added assertion
+    expect(warnIfMissingEnvVars('A', 'warn')).toBe(true); //should not warn //added assertion
+    expect(warnSpy).not.toHaveBeenCalled(); //warn not called //added check
+    expect(errorSpy).not.toHaveBeenCalled(); //error not called //added check
+    expect(qerrors).not.toHaveBeenCalled(); //qerrors not used directly //added check
+    expect(safeQerrors).toHaveBeenCalledTimes(3); //safeQerrors invoked for each function //added check
+  });
+
   test('does not log when DEBUG false', () => { //verify debug gating
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {}); //spy on console.log
     delete process.env.DEBUG; //ensure debug flag unset

--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -20,6 +20,10 @@ const DEBUG = getDebugFlag(); //determine current debug state
 
 // Helper replicates old safeRun behavior synchronously for env checks
 function calcMissing(varArr) {
+       if (!Array.isArray(varArr)) { //ensure input is array before proceeding //added early validation
+               safeQerrors(new Error('varArr not array'), 'calcMissing invalid input', { varArr }); //log misuse for debugging //added error report
+               return []; //avoid throwing by returning empty array //added safe fallback
+       }
        try { //attempt to filter normally without upfront checks to mimic prior behavior
                return varArr.filter(name => !process.env[name]);
        } catch (err) {


### PR DESCRIPTION
## Summary
- protect `calcMissing` in `envUtils` against non-array inputs
- test behavior with invalid argument type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68508bcaf8b08322a87b0eadcf4a6779