### PR TITLE
Fix sanitizeApiKey non-string input

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -301,6 +301,17 @@ describe('qserp module', () => { //group qserp tests
     if (savedDebug !== undefined) { process.env.DEBUG = savedDebug; } else { delete process.env.DEBUG; } //restore debug
   });
 
+  test('sanitizeApiKey handles non-string input', () => { //verify coercion to string
+    jest.resetModules(); //reload module for clean state
+    const { setTestEnv } = require('./utils/testSetup'); //env helper for vars
+    setTestEnv(); //ensure required env vars present
+    const { sanitizeApiKey } = require('../lib/qserp'); //load module under test
+    const numRes = sanitizeApiKey(12345); //number input
+    const objRes = sanitizeApiKey({ a: 1 }); //object input
+    expect(numRes).toBe('12345'); //returns string version of number
+    expect(objRes).toBe('[object Object]'); //returns object converted to string
+  });
+
   test('cache helpers log when DEBUG true', () => { //verify logging occurs
     const savedDebug = process.env.DEBUG; //preserve env var
     process.env.DEBUG = 'true'; //enable debug output

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -89,7 +89,7 @@ function sanitizeApiKey(text) { //mask api key values without altering param nam
                 const rawParamRegex = currentKey ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //match key after '=' to keep name
                 const encParamRegex = currentKey ? new RegExp(`([?&][^=&]*%3D)${encodeURIComponent(currentKey)}`, 'gi') : null; //match encoded '=' forms
                 const plainRegex = currentKey ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //match standalone key not followed by '='
-                sanitizedInput = typeof text === 'string' ? text : text; //ensure string handling
+                sanitizedInput = String(text); //coerce input to string for safe replacement
                 if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //replace param value only
                 if (encParamRegex) sanitizedInput = sanitizedInput.replace(encParamRegex, '$1[redacted]'); //replace encoded param value
                 if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //replace standalone key
@@ -100,7 +100,7 @@ function sanitizeApiKey(text) { //mask api key values without altering param nam
                 const escKey = currentKey ? currentKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape for fallback regex
                 const rawParamRegex = currentKey ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //fallback param regex
                 const plainRegex = currentKey ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //fallback plain regex
-                sanitizedInput = typeof text === 'string' ? text : text; //retain original type
+                sanitizedInput = String(text); //coerce input to string for safe fallback
                 if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //mask value portion
                 if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //mask plain occurrences
                 if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //trace fallback


### PR DESCRIPTION
## Summary
- coerce input to string inside `sanitizeApiKey`
- test that numbers and objects are accepted by `sanitizeApiKey`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68508bdbe7f08322b3f2a257bebcd327