### PR TITLE
Handle rejected safeQerrors promises

### DIFF
--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -23,7 +23,7 @@ function calcMissing(varArr) {
        try { //attempt to filter normally without upfront checks to mimic prior behavior
                return varArr.filter(name => !process.env[name]);
        } catch (err) {
-               safeQerrors(err, 'getMissingEnvVars error', { varArr }); //report filter failure
+               safeQerrors(err, 'getMissingEnvVars error', { varArr }).catch(() => {}); //report filter failure while swallowing rejection
                return []; //fallback to empty array on error
        }
 }
@@ -79,7 +79,7 @@ function throwIfMissingEnvVars(varArr) {
                // Report through safeQerrors with context for structured error tracking
                // CONTEXT INCLUSION: varArr provides debugging context about which variables
                // were being validated when the error occurred
-               safeQerrors(err, 'throwIfMissingEnvVars error', { varArr }); //use wrapped error reporter for resilience
+               safeQerrors(err, 'throwIfMissingEnvVars error', { varArr }).catch(() => {}); //use wrapped error reporter for resilience and swallow rejection
                
                throw err; // Fail fast - required variables are non-negotiable
        }


### PR DESCRIPTION
## Summary
- swallow rejections from safeQerrors inside envUtils
- ensure mocked safeQerrors returns a promise in tests
- add test verifying rejected safeQerrors promises do not trigger unhandled rejection

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68508bf1cc948322ab192bc9390a0f6d