### PR TITLE
Ensure int env vars fully numeric

### DIFF
--- a/__tests__/envValidator.test.js
+++ b/__tests__/envValidator.test.js
@@ -84,11 +84,20 @@ describe('envValidator', () => { // envValidator
 
         it('should handle floating point numbers by truncating to integer', () => { // should handle floating point numbers by truncating to integer
             process.env.TEST_VAR = '75.8';
-            
+
             const result = parseIntWithBounds('TEST_VAR', 50, 10, 100);
-            
+
             expect(result).toBe(75);
             expect(debugExit).toHaveBeenCalledWith('parseIntWithBounds', 75);
+        });
+
+        it('should fallback to default for values with trailing characters', () => { // ensure trailing chars are rejected
+            process.env.TEST_VAR = '10abc';
+
+            const result = parseIntWithBounds('TEST_VAR', 50, 10, 100);
+
+            expect(result).toBe(50);
+            expect(debugExit).toHaveBeenCalledWith('parseIntWithBounds', 50);
         });
 
         it('should handle negative values correctly with negative bounds', () => { // should handle negative values correctly with negative bounds

--- a/lib/envValidator.js
+++ b/lib/envValidator.js
@@ -31,12 +31,13 @@ const { debugEntry, debugExit } = require('./debugUtils'); //use unified debug u
  */
 function parseIntWithBounds(varName, defaultValue, minValue, maxValue) {
     debugEntry('parseIntWithBounds', `${varName}, default: ${defaultValue}, range: ${minValue}-${maxValue}`);
-    
-    // Parse environment variable with proper zero handling
-    // ZERO VALUE FIX: Use isNaN check instead of || operator to allow legitimate zero values
-    // This prevents configuration issues where 0 is a valid setting (cache disabled, unlimited rate)
-    const envValue = parseInt(process.env[varName], 10); //explicit base 10 avoids octal issues
-    const rawValue = !isNaN(envValue) ? envValue : defaultValue;
+
+    // Improved validation rejects strings with trailing characters
+    // VALIDATION UPDATE: ensure entire value is numeric before parsing to prevent partial parsing of values like '10abc'
+    const rawString = (process.env[varName] || '').trim(); //obtain env var as string
+    const numericMatch = /^-?\d+(?:\.\d+)?$/.test(rawString); //regex validates full numeric string
+    const envValue = numericMatch ? parseInt(rawString, 10) : NaN; //parse only if valid
+    const rawValue = !isNaN(envValue) ? envValue : defaultValue; //retain default when NaN
     
     // Apply bounds checking for security and stability
     // Math.max ensures value >= minValue, Math.min ensures value <= maxValue


### PR DESCRIPTION
## Summary
- enforce strict numeric validation in `parseIntWithBounds`
- reject env values that contain trailing characters
- test fallback to default when env value has trailing characters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850ac95dfac832282f02ac14a9c6c0d