### PR TITLE
Move CODEX check before cache logic

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -165,6 +165,19 @@ test('fetchSearchItems bypasses url build in CODEX mode', async () => { // fetch
   delete process.env.CODEX; //cleanup codex flag
 }); //test verifies fetchSearchItems skips url creation and internal request when CODEX true
 
+test('fetchSearchItems does not create cache key in CODEX mode', async () => { //ensure cache bypassed
+  process.env.CODEX = 'true'; //enable codex offline
+  ({ mock, scheduleMock, qerrorsMock } = initSearchTest()); //reinitialize mocks
+  const qserp = require('../lib/qserp'); //require module with CODEX true
+  const keySpy = jest.spyOn(qserp, 'createCacheKey'); //spy on key creation helper
+  const res = await qserp.fetchSearchItems('skipKey'); //invoke fetch expecting bypass
+  expect(res).toEqual([]); //mocked empty array
+  expect(keySpy).not.toHaveBeenCalled(); //no cache key generated
+  expect(qserp.performCacheCleanup()).toBe(false); //cache remains empty
+  keySpy.mockRestore(); //restore spy
+  delete process.env.CODEX; //clean environment
+}); //test ensures CODEX mode avoids cache access
+
 test('validateSearchQuery accepts non-empty strings', () => { //(verify valid input)
   const { validateSearchQuery } = require('../lib/qserp'); //import helper
   expect(validateSearchQuery('ok')).toBe(true); //should return true for normal string

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -397,6 +397,12 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
         if (DEBUG) { logStart('fetchSearchItems', query); } //(start log when debug)
         validateSearchQuery(query); //(reuse validation helper)
         try {
+               if (String(process.env.CODEX).trim().toLowerCase() === 'true') { //(mock path when codex true using trimmed case-insensitive check)
+
+                       const items = []; //use static empty array without network call
+                       if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log mock return)
+                       return items; //return mock array directly without cache or network
+               }
 
                // Normalize num once to share between cache key and URL
                const safeNum = normalizeNum(num); //clamp value or null when invalid
@@ -417,16 +423,7 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                        }
                }
 
-
-             if (String(process.env.CODEX).trim().toLowerCase() === 'true') { //(mock path when codex true using trimmed case-insensitive check)
-
-                     const items = []; //use static empty array without network call
-                     // skip cache set so CODEX calls do not pollute cache //(omit caching when offline)
-                     if (DEBUG) { logReturn('fetchSearchItems', JSON.stringify(items)); } //(log mock return)
-                     return items; //return mock array directly without calling rateLimitedRequest
-             }
-
-              const url = getGoogleURL(query, safeNum); //(build search url with clamped num)
+               const url = getGoogleURL(query, safeNum); //(build search url with clamped num)
 
                const response = await rateLimitedRequest(url); //(perform rate limited axios request)
                const items = response.data.items || []; //(extract items array if present)


### PR DESCRIPTION
## Summary
- handle CODEX mode early in `fetchSearchItems` before any cache key is created
- test that CODEX offline mode never creates cache keys or populates cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850ac9af6f88322813038e497028e55