### PR TITLE
Add encoded query sanitization

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -187,6 +187,13 @@ test('sanitizeApiKey ignores partial-word matches', () => { //verify no substrin
   expect(res).toBe('monkey business key=[redacted]'); //only value replaced
 });
 
+test('sanitizeApiKey masks encoded api key parameters', () => { //verify encoded value replaced
+  process.env.GOOGLE_API_KEY = 'a+b'; //set key with special char
+  const { sanitizeApiKey } = require('../lib/qserp'); //load function
+  const res = sanitizeApiKey(`http://x?key=${encodeURIComponent('a+b')}`); //call with encoded value
+  expect(res).toBe('http://x?key=[redacted]'); //value should be masked
+});
+
 test('sanitizeApiKey returns sanitized string when regex fails', () => { //trigger catch branch
   const savedDebug = process.env.DEBUG; //preserve debug flag
   process.env.DEBUG = 'true'; //enable debug logging

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -96,12 +96,14 @@ function sanitizeApiKey(text) { //mask api key values without altering param nam
                 const currentKey = process.env.GOOGLE_API_KEY || defaultApiKey; //read current key each call
                 const escKey = currentKey ? currentKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape regex metachars
                 const rawParamRegex = currentKey ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //match key after '=' to keep name
+                const encValueRegex = currentKey ? new RegExp(`([?&][^=&]*=)${encodeURIComponent(currentKey)}`, 'g') : null; //match encoded value without encoded '='
                 const encParamRegex = currentKey ? new RegExp(`([?&][^=&]*%3D)${encodeURIComponent(currentKey)}`, 'gi') : null; //match encoded '=' forms
                 const plainRegex = currentKey ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //match standalone key not followed by '='
 
                 sanitizedInput = String(text); //normalize to string for safe replace calls
 
                 if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //replace param value only
+                if (encValueRegex) sanitizedInput = sanitizedInput.replace(encValueRegex, '$1[redacted]'); //replace encoded value without encoded '='
                 if (encParamRegex) sanitizedInput = sanitizedInput.replace(encParamRegex, '$1[redacted]'); //replace encoded param value
                 if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //replace standalone key
                 if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //trace sanitized input


### PR DESCRIPTION
## Summary
- sanitize encoded API key values in query parameters
- test masking of encoded API key values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850acb9af048322a6cfa1090cfcd15a