### PR TITLE
Handle env utils promises

### DIFF
--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -12,6 +12,9 @@
 
 // Import safeQerrors using shared loader
 const { safeQerrors } = require('./qerrorsLoader'); //retrieve safe wrapper for qerrors
+// safeQerrors is async; calls below use `void` to discard the returned promise
+// This prevents Node from warning about an unhandled promise while keeping
+// these utility functions synchronous for simplicity
 const { logStart, logReturn } = require('./logUtils'); //import standardized log utilities
 // safeRun now returns a promise; env utils implement sync logic internally
 const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility
@@ -23,7 +26,7 @@ function calcMissing(varArr) {
        if (DEBUG) { logStart('calcMissing', varArr); } //trace call for debugging
 
        if (!Array.isArray(varArr)) { //validate input type before filter
-               safeQerrors(new Error('varArr must be array'), 'calcMissing invalid varArr', { varArr }); //report invalid value
+               void Promise.resolve(safeQerrors(new Error('varArr must be array'), 'calcMissing invalid varArr', { varArr })).catch(() => {}); //wrap in Promise to handle rejections consistently
                if (DEBUG) { logReturn('calcMissing', []); } //trace fallback result
                return []; //graceful fallback when parameter invalid
        }
@@ -33,7 +36,7 @@ function calcMissing(varArr) {
                if (DEBUG) { logReturn('calcMissing', result); } //trace filtered list
                return result; //return computed array
        } catch (err) {
-               safeQerrors(err, 'getMissingEnvVars error', { varArr }); //report filter failure
+               void Promise.resolve(safeQerrors(err, 'getMissingEnvVars error', { varArr })).catch(() => {}); //ensure catch even when mock not promise
                if (DEBUG) { logReturn('calcMissing', []); } //trace fallback result
                return []; //fallback to empty array on error
        }
@@ -90,7 +93,7 @@ function throwIfMissingEnvVars(varArr) {
                // Report through safeQerrors with context for structured error tracking
                // CONTEXT INCLUSION: varArr provides debugging context about which variables
                // were being validated when the error occurred
-               safeQerrors(err, 'throwIfMissingEnvVars error', { varArr }); //use wrapped error reporter for resilience
+               void Promise.resolve(safeQerrors(err, 'throwIfMissingEnvVars error', { varArr })).catch(() => {}); //normalize return for consistent promise handling
                
                throw err; // Fail fast - required variables are non-negotiable
        }


### PR DESCRIPTION
## Summary
- avoid dropped error logs by explicitly catching safeQerrors promises
- test for unhandled rejections

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6850b3567e6c8322a542dba01561518a