### PR TITLE
Improve cache size validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ These variables enhance functionality but are not required:
 - `LOG_LEVEL` – Controls `warn` and `error` output (`info` by default)
 
 - `QSERP_MAX_CACHE_SIZE` – Maximum cache entries (default: 1000, range: 0-50000 (0 disables caching)) for memory management
+  Non-numeric values are ignored and the default is used.
 
 - `GOOGLE_REFERER` – Adds a Referer header to requests when set
 

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -58,10 +58,9 @@ const CACHE_TTL = 300000; //5 minute cache lifespan in ms
 // long-running applications with many unique queries could accumulate significant memory.
 // These constants provide configurable limits to prevent unbounded growth.
 // SECURITY ENHANCEMENT: Validate environment values to prevent malicious configuration
-// ZERO VALUE FIX: Use isNaN check to allow cache size of 0 (disables caching)
-const envCacheSize = parseInt(process.env.QSERP_MAX_CACHE_SIZE, 10); //parse decimal to avoid octal interpretation
-const rawMaxSize = !isNaN(envCacheSize) ? envCacheSize : 1000;
-const MAX_CACHE_SIZE = Math.max(0, Math.min(rawMaxSize, 50000)); // Allow 0 to disable caching
+// STRICT PARSING: use centralized utility to reject non-numeric values like '10abc'
+const { parseIntWithBounds } = require('./envValidator'); //import validator utility for env integers
+const MAX_CACHE_SIZE = parseIntWithBounds('QSERP_MAX_CACHE_SIZE', 1000, 0, 50000); //parse with clamping 0-50000
 
 // Initialize LRU cache with automatic memory management
 // OPTIMIZATION: LRU-cache handles eviction automatically, preventing memory leaks


### PR DESCRIPTION
## Summary
- use `parseIntWithBounds()` when reading `QSERP_MAX_CACHE_SIZE`
- document default fallback for non-numeric cache size values
- test cache size fallback when env value is invalid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850b337899883229138d79fc081f43e