### PR TITLE
Fix fetchSearchItems undefined response

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -347,4 +347,12 @@ describe('qserp module', () => { //group qserp tests
     logSpy.mockRestore(); //cleanup
     if (savedDebug !== undefined) { process.env.DEBUG = savedDebug; } else { delete process.env.DEBUG; } //restore env
   });
+
+  test('fetchSearchItems handles undefined response gracefully', async () => { //new edge case test
+    const qserp = require('../lib/qserp');
+    const spy = jest.spyOn(qserp, 'rateLimitedRequest').mockResolvedValueOnce(undefined); //simulate missing response
+    const items = await qserp.fetchSearchItems('undef'); //call with spy
+    expect(items).toEqual([]); //should return empty array
+    spy.mockRestore(); //cleanup spy
+  });
 });

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -428,7 +428,7 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                const url = getGoogleURL(query, safeNum); //(build search url with clamped num)
 
                const response = await rateLimitedRequest(url); //(perform rate limited axios request)
-               const items = response.data.items || []; //(extract items array if present)
+               const items = Array.isArray(response?.data?.items) ? response.data.items : []; //optional chaining prevents crash when response or data missing
                
                // Store in LRU cache - TTL and size limits handled automatically
                // OPTIMIZATION: LRU-cache manages expiry and eviction without manual intervention


### PR DESCRIPTION
## Summary
- guard against undefined response objects in `fetchSearchItems`
- test that undefined API response is handled safely

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850b351fc5c8322b6b344b74b1bac04