### PR TITLE
Improve reportError false return handling

### DIFF
--- a/__tests__/errorUtils.test.js
+++ b/__tests__/errorUtils.test.js
@@ -173,6 +173,22 @@ describe('errorUtils', () => { // errorUtils
             expect(consoleErrorSpy).toHaveBeenCalledWith('Error reporting failed:', expect.any(Error));
             expect(consoleErrorSpy).toHaveBeenCalledWith('Original error:', error);
         });
+
+        it('should return false when safeQerrors resolves false', async () => { //verify failure branch without throw
+            const { reportError } = require('../lib/errorUtils');
+
+            mockSafeQerrors.mockResolvedValue(false); //simulate failure result
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {}); //capture logReturn output
+
+            const error = new Error('Original error');
+
+            const result = await reportError(error, 'Test message'); //invoke async function
+
+            expect(result).toBe(false); //function should propagate failure
+            expect(logSpy).toHaveBeenCalledWith('reportError returning failure'); //ensure failure branch logged
+
+            logSpy.mockRestore(); //cleanup spy
+        });
     });
 
     describe('convenience reporting functions', () => { // convenience reporting functions

--- a/lib/errorUtils.js
+++ b/lib/errorUtils.js
@@ -108,9 +108,12 @@ async function reportError(error, message, context = {}, customDetails = {}) {
                         ...context,
                         ...customDetails
                 };
-
-                await safeQerrors(error, message, enrichedContext); //await async error report to capture result
-                logReturn('reportError', 'success'); //trace success
+                const result = await safeQerrors(error, message, enrichedContext); //capture result from safeQerrors
+                if (result === false) { //check if reporting failed as indicated by safeQerrors
+                        logReturn('reportError', 'failure'); //trace failure branch for log analysis
+                        return false; //propagate failure to caller
+                }
+                logReturn('reportError', 'success'); //trace success only when result is not false
                 return true; //indicate handled
         } catch (reportingError) {
                 console.error('Error reporting failed:', reportingError); //fallback log


### PR DESCRIPTION
## Summary
- capture the result of `safeQerrors` in `reportError`
- report failure when `safeQerrors` returns `false`
- test failure branch when `safeQerrors` resolves to `false`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850ba570cf083228b347645c3d25a21