### PR TITLE
Fix normalizeNum validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Fetches raw Google Custom Search API items for a query. Optional `num` limits th
 
 **Parameters:**
 - `query` (string): The search query (must be non-empty)
-- `num` (number, optional): Maximum number of items to return (range 1-10; values outside this range are clamped). Non-numeric values use the default of 10
+- `num` (number, optional): Maximum number of items to return (range 1-10; only integer strings are accepted). Any other value falls back to the default of 10
 
 **Returns:**
 - `Promise<Array>`: Raw items array from Google API or empty array on error

--- a/__tests__/createCacheKey.test.js
+++ b/__tests__/createCacheKey.test.js
@@ -34,7 +34,6 @@ describe('createCacheKey', () => {
 
   test.each([
     [0, 1],
-    [-1, 1],
     [11, 10]
   ])('clamps out of range %p to %p', (input, clamp) => { //verify clamping logic
     const { createCacheKey } = require('../lib/qserp');
@@ -42,9 +41,10 @@ describe('createCacheKey', () => {
     expect(res).toBe(`clamp:${clamp}`); //should use clamped value
   });
 
-  test.each([undefined, null, NaN, 'bad'])('omits num when invalid %p', val => { //verify omission on invalid values
+  test.each([undefined, null, NaN, 'bad', -1])('omits num when invalid %p', val => { //verify omission on invalid values
     const { createCacheKey } = require('../lib/qserp');
     const res = createCacheKey('NoNum', val); //call with invalid value
     expect(res).toBe('nonum'); //should return normalized query only
   });
+
 });

--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -265,6 +265,12 @@ test('normalizeNum returns null when parseInt throws', () => { //validate catch 
   logSpy.mockRestore(); //restore console
 });
 
+test.each(['10abc', '4.5'])('normalizeNum returns null for invalid integer strings %p', val => { //reject mixed characters and decimals
+  const { normalizeNum } = require('../lib/qserp'); //load helper
+  const res = normalizeNum(val); //validate with invalid input
+  expect(res).toBeNull(); //should return null for invalid string
+});
+
 test.each(['plain error', { foo: 'bar' }])('handleAxiosError handles %p input', async val => {
   const { handleAxiosError } = require('../lib/qserp'); //load function under test
   const res = await handleAxiosError(val, 'ctx'); //invoke with arbitrary input

--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -167,7 +167,7 @@ describe('qserp module', () => { //group qserp tests
 
   test.each([
     [0, 1],
-    [-1, 1],
+    [-1, 10],
     [11, 10]
   ])('invalid num %i shares cache with %i', async (bad, clamp) => { //new cache clamp test
     mock.onGet(/Clamp/).reply(200, { items: [{ link: 'x' }] }); //mock first response
@@ -212,10 +212,15 @@ describe('qserp module', () => { //group qserp tests
     expect(url).toBe('https://customsearch.googleapis.com/customsearch/v1?q=Val&key=key&cx=cx&fields=items(title,snippet,link)&num=5'); //string should parse to num 5
   });
 
-  test.each([0, -1, 11])('getGoogleURL clamps out of range %i', bad => { //invalid values clamp to range
+  test.each([0, 11])('getGoogleURL clamps out of range %i', bad => { //invalid values clamp to range
     const url = getGoogleURL('Bad', bad); //build url with invalid num
     const clamped = bad < 1 ? 1 : 10; //expected clamp result
     expect(url).toBe(`https://customsearch.googleapis.com/customsearch/v1?q=Bad&key=key&cx=cx&fields=items(title,snippet,link)&num=${clamped}`); //should clamp
+  });
+
+  test('getGoogleURL omits num for negative input', () => { //ensure negatives are rejected
+    const url = getGoogleURL('Bad', -1); //build url with negative num
+    expect(url).toBe('https://customsearch.googleapis.com/customsearch/v1?q=Bad&key=key&cx=cx&fields=items(title,snippet,link)'); //num parameter absent
   });
 
   test('disables caching when env var is zero', async () => { //new zero cache test

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -229,11 +229,12 @@ warnIfMissingEnvVars(['GOOGLE_REFERER']); //default warning without custom messa
 function normalizeNum(num) { //return clamped integer or null for invalid input
        if (DEBUG) { console.log(`normalizeNum is running with ${num}`); } //debug trace start when enabled
        try {
-               const parsed = parseInt(num, 10); //parse numeric strings to integers before validation
-               let safe = Number.isFinite(parsed) ? parsed : null; //validate the parsed value is a real number
-               if (safe !== null) { safe = Math.min(Math.max(safe, 1), 10); } //clamp between 1 and 10 when provided
+               const str = String(num).trim(); //convert to trimmed string for validation
+               if (!/^\d+$/.test(str)) { if (DEBUG) { console.log('normalizeNum is returning null'); } return null; } //reject non-integer strings
+               let safe = parseInt(str, 10); //parse validated digits into number
+               safe = Math.min(Math.max(safe, 1), 10); //clamp value to accepted range
                if (DEBUG) { console.log(`normalizeNum is returning ${safe}`); } //debug trace return when enabled
-               return safe; //propagate normalized number or null
+               return safe; //propagate normalized number
        } catch (err) {
                if (DEBUG) { console.log('normalizeNum is returning null'); } //debug trace for errors when enabled
                return null; //return null if normalization fails


### PR DESCRIPTION
## Summary
- validate `num` parameter strictly in `normalizeNum`
- document integer-only behavior for `num`
- test invalid integer strings in internal unit tests
- update cache key and URL tests for new validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850ba7a1b248322ac88dcec87b98429