### PR TITLE
Add safeQerrors false case

### DIFF
--- a/__tests__/errorUtils.test.js
+++ b/__tests__/errorUtils.test.js
@@ -11,6 +11,7 @@ const mockSafeQerrors = jest.fn();
 jest.mock('../lib/qerrorsLoader', () => ({
     safeQerrors: mockSafeQerrors //provide safeQerrors for tests
 }));
+const { mockConsole } = require('./utils/consoleSpies'); //helper for log spies
 
 describe('errorUtils', () => { // errorUtils
     let consoleErrorSpy;
@@ -172,6 +173,19 @@ describe('errorUtils', () => { // errorUtils
             expect(result).toBe(false);
             expect(consoleErrorSpy).toHaveBeenCalledWith('Error reporting failed:', expect.any(Error));
             expect(consoleErrorSpy).toHaveBeenCalledWith('Original error:', error);
+        });
+
+        it('should return false when qerrors resolves false', async () => { //fail when safeQerrors returns false
+            const { reportError } = require('../lib/errorUtils');
+            const logSpy = mockConsole('log'); //capture log messages
+
+            mockSafeQerrors.mockResolvedValueOnce(false); //simulate wrapper failure without throw
+
+            const result = await reportError(new Error('simple'), 'msg'); //invoke function under test
+
+            expect(result).toBe(false);
+            expect(logSpy).not.toHaveBeenCalledWith('reportError returning success');
+            logSpy.mockRestore(); //cleanup spy
         });
     });
 

--- a/lib/errorUtils.js
+++ b/lib/errorUtils.js
@@ -109,7 +109,11 @@ async function reportError(error, message, context = {}, customDetails = {}) {
                         ...customDetails
                 };
 
-                await safeQerrors(error, message, enrichedContext); //await async error report to capture result
+                const res = await safeQerrors(error, message, enrichedContext); //await error reporting and capture result
+                if (res === false) { //safeQerrors failed to report
+                        logReturn('reportError', 'failure'); //trace failure result
+                        return false; //propagate failure to caller
+                }
                 logReturn('reportError', 'success'); //trace success
                 return true; //indicate handled
         } catch (reportingError) {


### PR DESCRIPTION
## Summary
- add console spy helper to errorUtils tests
- test reportError behavior when safeQerrors resolves false
- handle failure return in reportError implementation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6850ba5c4d688322a3a2cd8539794f1b