### PR TITLE
Fix calcMissing error context

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -85,6 +85,14 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     expect(safeQerrors).toHaveBeenCalledTimes(3); //safeQerrors invoked three times //(check)
   });
 
+  test('safeQerrors context for calcMissing error', () => { //verify catch block context
+    const { getMissingEnvVars } = require('../lib/envUtils'); //require utils fresh
+    const arr = ['A']; //valid array base for filter
+    arr.filter = () => { throw new Error('boom'); }; //force error during filter
+    expect(getMissingEnvVars(arr)).toEqual([]); //should fallback to empty array
+    expect(safeQerrors).toHaveBeenCalledWith(expect.any(Error), 'calcMissing error', { varArr: arr }); //ensure context string
+  });
+
   test('does not log when DEBUG false', () => { //verify debug gating
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {}); //spy on console.log
     delete process.env.DEBUG; //ensure debug flag unset

--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -36,7 +36,7 @@ function calcMissing(varArr) {
                if (DEBUG) { logReturn('calcMissing', result); } //trace filtered list
                return result; //return computed array
        } catch (err) {
-               void Promise.resolve(safeQerrors(err, 'getMissingEnvVars error', { varArr })).catch(() => {}); //ensure catch even when mock not promise
+               void Promise.resolve(safeQerrors(err, 'calcMissing error', { varArr })).catch(() => {}); //report unexpected calcMissing failure with context
                if (DEBUG) { logReturn('calcMissing', []); } //trace fallback result
                return []; //fallback to empty array on error
        }


### PR DESCRIPTION
## Summary
- report 'calcMissing error' context when filtering fails
- test safeQerrors is passed the calcMissing error context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850ba73515483229ae52d3f78eebace