### PR TITLE
Fix noop cache purge

### DIFF
--- a/__tests__/cacheSizeParsing.test.js
+++ b/__tests__/cacheSizeParsing.test.js
@@ -25,7 +25,7 @@ test('parses QSERP_MAX_CACHE_SIZE with leading zero as decimal', () => { // pars
     get: jest.fn(), // placeholder methods for interface compatibility
     set: jest.fn(), // cache setter mock to avoid actual caching
     clear: jest.fn(), // clear mock
-    purgeStale: jest.fn(() => 0), // stub TTL cleanup
+    purgeStale: jest.fn(() => false), // stub TTL cleanup
     size: 0
   })); // mock constructor to inspect configuration
   jest.doMock('lru-cache', () => ({ LRUCache: LRUCacheMock })); // replace lru-cache so we can check max option
@@ -43,7 +43,7 @@ test('invalid QSERP_MAX_CACHE_SIZE falls back to default', () => { // non-numeri
     get: jest.fn(), // placeholder methods for interface compatibility
     set: jest.fn(), // cache setter mock to avoid actual caching
     clear: jest.fn(), // clear mock
-    purgeStale: jest.fn(() => 0), // stub TTL cleanup
+    purgeStale: jest.fn(() => false), // stub TTL cleanup
     size: 0
   })); // mock constructor to inspect configuration
   jest.doMock('lru-cache', () => ({ LRUCache: LRUCacheMock })); // replace lru-cache so we can check max option

--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -244,7 +244,7 @@ describe('qserp module', () => { //group qserp tests
     jest.resetModules(); //reload module with noop cache
     const { clearCache: clearLocal, performCacheCleanup } = require('../lib/qserp'); //require fresh module
     expect(clearLocal()).toBe(true); //clearCache should succeed
-    expect(performCacheCleanup()).toBe(0); //no stale entries removed
+    expect(performCacheCleanup()).toBe(false); //no stale entries removed
     process.env.QSERP_MAX_CACHE_SIZE = savedSize; //restore env value
   });
 

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -66,7 +66,7 @@ const MAX_CACHE_SIZE = parseIntWithBounds('QSERP_MAX_CACHE_SIZE', 1000, 0, 50000
 // OPTIMIZATION: LRU-cache handles eviction automatically, preventing memory leaks
 // and providing better performance than manual Map-based cleanup
 const cache = MAX_CACHE_SIZE === 0 ? //create noop cache when disabled
-        { get: () => undefined, set: () => {}, clear: () => {}, purgeStale: () => 0, size: 0 } : //noop methods keep API but skip storage and expose same interface
+        { get: () => undefined, set: () => {}, clear: () => {}, purgeStale: () => false, size: 0 } : //noop methods keep API but skip storage and expose same interface; purgeStale now returns boolean to match LRU implementation
         new LRUCache({
                 max: MAX_CACHE_SIZE || 1000,  //LRU max entries when enabled
                 ttl: CACHE_TTL,               // Time-to-live in milliseconds
@@ -465,7 +465,7 @@ function clearCache() {
  * already handles expiry automatically so this shouldn't be needed in normal
  * operation.
  *
- * @returns {boolean} true if any stale entries were removed
+ * @returns {boolean} true if any stale entries were removed, false otherwise
  */
 function performCacheCleanup() {
         if (DEBUG) { logStart('performCacheCleanup', cache.size); } //trace start when debugging


### PR DESCRIPTION
## Summary
- return `false` from noop `purgeStale` to mirror LRU behavior
- update `performCacheCleanup` JSDoc
- expect `false` when cache cleanup runs with caching disabled
- adjust test cache mocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850ba6ef42c8322be8ef4ff0ac999c0