### PR TITLE
Fix decimal validation in env parser

### DIFF
--- a/__tests__/envValidator.test.js
+++ b/__tests__/envValidator.test.js
@@ -82,13 +82,13 @@ describe('envValidator', () => { // envValidator
             expect(debugExit).toHaveBeenCalledWith('parseIntWithBounds', 50);
         });
 
-        it('should handle floating point numbers by truncating to integer', () => { // should handle floating point numbers by truncating to integer
+        it('should fallback to default for floating point numbers', () => { // decimals are invalid; default should be used
             process.env.TEST_VAR = '75.8';
 
             const result = parseIntWithBounds('TEST_VAR', 50, 10, 100);
 
-            expect(result).toBe(75);
-            expect(debugExit).toHaveBeenCalledWith('parseIntWithBounds', 75);
+            expect(result).toBe(50);
+            expect(debugExit).toHaveBeenCalledWith('parseIntWithBounds', 50);
         });
 
         it('should fallback to default for values with trailing characters', () => { // ensure trailing chars are rejected

--- a/lib/envValidator.js
+++ b/lib/envValidator.js
@@ -35,7 +35,7 @@ function parseIntWithBounds(varName, defaultValue, minValue, maxValue) {
     // Improved validation rejects strings with trailing characters
     // VALIDATION UPDATE: ensure entire value is numeric before parsing to prevent partial parsing of values like '10abc'
     const rawString = (process.env[varName] || '').trim(); //obtain env var as string
-    const numericMatch = /^-?\d+(?:\.\d+)?$/.test(rawString); //regex validates full numeric string
+    const numericMatch = /^-?\d+$/.test(rawString); //regex now only accepts whole numbers to reject decimals
     const envValue = numericMatch ? parseInt(rawString, 10) : NaN; //parse only if valid
     const rawValue = !isNaN(envValue) ? envValue : defaultValue; //retain default when NaN
     


### PR DESCRIPTION
## Summary
- enforce integer-only regex in `parseIntWithBounds`
- update floating-point test in `envValidator.test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850ba634f848322a4b822a01ca46494