### PR TITLE
Add dummy Google env vars

### DIFF
--- a/rate-limit-real-test.js
+++ b/rate-limit-real-test.js
@@ -2,6 +2,8 @@
 // Runs without CODEX mocks to inspect real throttling
 process.env.DEBUG = 'false'; // limit console noise during test
 delete process.env.CODEX; // enable real Bottleneck behavior instead of mocks
+process.env.GOOGLE_API_KEY = `test-key`; //dummy key ensures script runs without config
+process.env.GOOGLE_CX = `test-cx`; //dummy cx prevents env validation failure
 
 const qserp = require('./lib/qserp.js'); // module providing axios instance
 


### PR DESCRIPTION
## Summary
- add fake key and cx env vars in rate-limit test so it runs without setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850ba65fe788322bc0ecbbb1341d9d1