### PR TITLE
Add API key sanitizer to qerrorsLoader

### DIFF
--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -13,6 +13,15 @@
 const { logStart, logReturn } = require('./logUtils'); //import standardized logging utilities
 const { logError } = require('./minLogger'); //import error logging utility
 
+// Simple sanitizer to mask any instance of the Google API key in a string
+function sanitizeApiKey(text) { //avoid leaking sensitive key in logs
+        const key = process.env.GOOGLE_API_KEY; //retrieve current key from env
+        const sanitized = key ? String(text).split(key).join('[redacted]') : String(text); //replace key with placeholder
+        logStart('sanitizeApiKey', sanitized); //trace sanitized input for debug
+        logReturn('sanitizeApiKey', sanitized); //trace sanitized output for debug
+        return sanitized; //return sanitized string to caller
+}
+
 /**
  * Loads and normalizes the qerrors function from the qerrors module
  * 
@@ -91,15 +100,18 @@ async function safeQerrors(error, context, additionalData = {}) { //async to ret
         } catch (qerrorsError) {
                 // qerrors itself failed - fall back to basic logging
                 try {
-                        logError(`qerrors failed: ${qerrorsError.message.replace(/\n/g,' ')}`); //sanitize nested message
-                        logError(`Original error: ${safeMsg}`); //log sanitized original message
-                        logError(`Context: ${context}`);
+                        const failMsg = sanitizeApiKey(qerrorsError.message.replace(/\n/g,' ')); //apply sanitizer to nested message
+                        const origMsg = sanitizeApiKey(safeMsg); //sanitize original error message
+                        const safeCtx = sanitizeApiKey(context); //sanitize provided context
+                        logError(`qerrors failed: ${failMsg}`); //log sanitized nested message
+                        logError(`Original error: ${origMsg}`); //log sanitized original message
+                        logError(`Context: ${safeCtx}`); //log sanitized context
                 } catch (logErr) {
                         // Even basic logging failed - use console as last resort
                         console.error('Critical: All error reporting systems failed');
-                        console.error('qerrors error:', qerrorsError.message.replace(/\n/g,' '));
-                        console.error('Original error:', safeMsg); //sanitized fallback output
-                        console.error('Context:', context);
+                        console.error('qerrors error:', sanitizeApiKey(qerrorsError.message.replace(/\n/g,' '))); //sanitize nested message for console
+                        console.error('Original error:', sanitizeApiKey(safeMsg)); //sanitize original for console
+                        console.error('Context:', sanitizeApiKey(context)); //sanitize context for console
                 }
                 logReturn('safeQerrors', 'failed');
                 return false;


### PR DESCRIPTION
## Summary
- mask API keys in qerrorsLoader logs via sanitizeApiKey
- use sanitizer in safeQerrors fallback messages
- test that fallback logging never leaks the raw API key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850cccd64948322b89decbf99fbfff8