### PR TITLE
Fix env utils type validation

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -63,9 +63,9 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
 
   test('handles undefined variable array', () => { //verify undefined input //(third case)
     const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('../lib/envUtils'); //require utils fresh //(ensure env captured)
-    expect(getMissingEnvVars(undefined)).toEqual([]); //returns empty array //(assert)
-    expect(throwIfMissingEnvVars(undefined)).toEqual([]); //throws handled //(assert)
-    expect(warnIfMissingEnvVars(undefined, 'warn')).toBe(true); //should not warn //(assert)
+    expect(() => getMissingEnvVars(undefined)).toThrow(TypeError); //should throw when param invalid //(assert)
+    expect(() => throwIfMissingEnvVars(undefined)).toThrow(TypeError); //should propagate error //(assert)
+    expect(() => warnIfMissingEnvVars(undefined, 'warn')).toThrow(TypeError); //should throw on misuse //(assert)
     expect(warnSpy).not.toHaveBeenCalled(); //warn not called //(check)
     expect(errorSpy).not.toHaveBeenCalled(); //error not called //(check)
     expect(qerrors).not.toHaveBeenCalled(); //qerrors not used directly //(check)
@@ -76,9 +76,9 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
   test('handles non-array variable type', () => { //verify invalid object input //(new case)
     const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('../lib/envUtils'); //require utils fresh //(ensure env captured)
     const badVal = { foo: 'bar' }; //object passed instead of array //(setup)
-    expect(getMissingEnvVars(badVal)).toEqual([]); //should return empty array //(assert)
-    expect(throwIfMissingEnvVars(badVal)).toEqual([]); //should not throw //(assert)
-    expect(warnIfMissingEnvVars(badVal, 'warn')).toBe(true); //should not warn //(assert)
+    expect(() => getMissingEnvVars(badVal)).toThrow(TypeError); //should throw when param invalid //(assert)
+    expect(() => throwIfMissingEnvVars(badVal)).toThrow(TypeError); //should also throw //(assert)
+    expect(() => warnIfMissingEnvVars(badVal, 'warn')).toThrow(TypeError); //should throw as well //(assert)
     expect(warnSpy).not.toHaveBeenCalled(); //warn not called //(check)
     expect(errorSpy).not.toHaveBeenCalled(); //error not called //(check)
     expect(qerrors).not.toHaveBeenCalled(); //qerrors not used directly //(check)
@@ -115,7 +115,7 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
       return loader;
     });
     const { getMissingEnvVars } = require('../lib/envUtils'); //require with mock
-    getMissingEnvVars(undefined); //trigger safeQerrors
+    expect(() => getMissingEnvVars(undefined)).toThrow(TypeError); //trigger safeQerrors while asserting throw
     setImmediate(() => { //allow promise microtask to run
       process.removeListener('unhandledRejection', handler); //cleanup listener
       done(); //complete test if no rejection

--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -25,10 +25,11 @@ const DEBUG = getDebugFlag(); //determine current debug state
 function calcMissing(varArr) {
        if (DEBUG) { logStart('calcMissing', varArr); } //trace call for debugging
 
-       if (!Array.isArray(varArr)) { //validate input type before filter
-               void Promise.resolve(safeQerrors(new Error('varArr must be array'), 'calcMissing invalid varArr', { varArr })).catch(() => {}); //wrap in Promise to handle rejections consistently
-               if (DEBUG) { logReturn('calcMissing', []); } //trace fallback result
-               return []; //graceful fallback when parameter invalid
+       if (!Array.isArray(varArr)) { //validate input and fail fast when not array
+               const err = new TypeError('varArr must be array'); //construct explicit type error
+               void Promise.resolve(safeQerrors(err, 'calcMissing invalid varArr', { varArr })).catch(() => {}); //fire and forget logging
+               if (DEBUG) { logReturn('calcMissing', 'TypeError'); } //trace thrown condition
+               throw err; //propagate misuse error to caller
        }
 
        try { //attempt to filter normally without upfront checks to mimic prior behavior


### PR DESCRIPTION
## Summary
- throw a TypeError when `calcMissing` gets a non-array value
- update env utils tests to assert on TypeError throwing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850d02444fc8322ae03288b5bdc3150