### PR TITLE
Improve safeQerrors fallback handling

### DIFF
--- a/__tests__/qerrorsLoader.test.js
+++ b/__tests__/qerrorsLoader.test.js
@@ -112,4 +112,16 @@ describe('safeQerrors', () => { //new tests for sanitized logging
     spy.mockRestore(); //cleanup
     if (savedKey !== undefined) { process.env.GOOGLE_API_KEY = savedKey; } else { delete process.env.GOOGLE_API_KEY; } //restore key
   });
+
+  test('returns false when thrown value lacks message', async () => { //non-Error input should not crash
+    jest.resetModules(); //reset module cache for clean mocks
+    let safeQerrors;
+    jest.isolateModules(() => { //isolate module for mocking
+      const qerr = jest.fn(() => { throw new Error('fail'); }); //mock qerrors that fails
+      jest.doMock('qerrors', () => qerr); //replace dependency
+      ({ safeQerrors } = require('../lib/qerrorsLoader')); //load function under test
+    });
+    const result = await safeQerrors({ bad: true }, 'ctx'); //object without message
+    expect(result).toBe(false); //should return false rather than throw
+  });
 });

--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -100,7 +100,7 @@ async function safeQerrors(error, context, additionalData = {}) { //async to ret
         } catch (qerrorsError) {
                 // qerrors itself failed - fall back to basic logging
                 try {
-                        const failMsg = sanitizeApiKey(qerrorsError.message.replace(/\n/g,' ')); //apply sanitizer to nested message
+                        const failMsg = sanitizeApiKey(String(qerrorsError && qerrorsError.message || qerrorsError).replace(/\n/g, ' ')); //safely sanitize nested error message
                         const origMsg = sanitizeApiKey(safeMsg); //sanitize original error message
                         const safeCtx = sanitizeApiKey(context); //sanitize provided context
                         logError(`qerrors failed: ${failMsg}`); //log sanitized nested message
@@ -109,7 +109,8 @@ async function safeQerrors(error, context, additionalData = {}) { //async to ret
                 } catch (logErr) {
                         // Even basic logging failed - use console as last resort
                         console.error('Critical: All error reporting systems failed');
-                        console.error('qerrors error:', sanitizeApiKey(qerrorsError.message.replace(/\n/g,' '))); //sanitize nested message for console
+                        const failMsg = sanitizeApiKey(String(qerrorsError && qerrorsError.message || qerrorsError).replace(/\n/g, ' ')); //safely sanitize nested error message for console
+                        console.error('qerrors error:', failMsg); //output sanitized nested message
                         console.error('Original error:', sanitizeApiKey(safeMsg)); //sanitize original for console
                         console.error('Context:', sanitizeApiKey(context)); //sanitize context for console
                 }


### PR DESCRIPTION
## Summary
- sanitize qerrors errors that lack `message` property in `safeQerrors`
- ensure console fallback uses same sanitized message
- test that `safeQerrors` safely handles thrown values without `message`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850d01c388483228ddae7962b8c9cd4