### PR TITLE
Fix safeQerrors context logging

### DIFF
--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -84,7 +84,8 @@ function loadQerrors() {
  * @returns {Promise<*>} - Result from qerrors or false on failure
  */
 async function safeQerrors(error, context, additionalData = {}) { //async to return awaited qerrors result
-        logStart('safeQerrors', context); //avoid leaking raw error message
+        const cleanCtx = sanitizeApiKey(context); //mask api key before logging context
+        logStart('safeQerrors', cleanCtx); //avoid leaking raw context value
 
         const safeMsg = String(error?.message || error).replace(/\n/g, ' '); //newline sanitize for later logs
         


### PR DESCRIPTION
## Summary
- sanitize context before passing to `logStart` in `safeQerrors`
- extend tests to ensure API key never appears in any logged output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850d50780e4832284ddc5f03fbc12d9