### PR TITLE
Fix deduplication for top search queries

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -90,6 +90,13 @@ describe('qserp module', () => { //group qserp tests
     expect(scheduleMock).toHaveBeenCalledTimes(2); //schedule called once per unique term
   });
 
+  test('deduplicates trimmed and case-insensitive terms', async () => { //new normalization test
+    mock.onGet(/Node\.js/).reply(200, { items: [{ link: 'http://n' }] }); //mock node search
+    const urls = await getTopSearchResults(['Node.js', ' node.js ', 'NODE.JS']); //variations of same term
+    expect(urls).toEqual(['http://n']); //single result expected
+    expect(scheduleMock).toHaveBeenCalledTimes(1); //only one api request
+  });
+
   test('warns on missing OPENAI_TOKEN for getTopSearchResults', async () => { //new warning test
     const tokenSave = process.env.OPENAI_TOKEN; //store existing token for restore
     delete process.env.OPENAI_TOKEN; //remove token to trigger warning logic

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -510,17 +510,21 @@ async function getTopSearchResults(searchTerms) {
                 throw new Error('searchTerms must be an array of strings');
         }
         
-        // Remove duplicates using Set while preserving original order
-        // DEDUPLICATION RATIONALE: Prevents redundant API calls for identical search terms,
-        // improving performance and reducing quota usage. Spread operator maintains array order.
-        const uniqueTerms = [...new Set(searchTerms)];
-        
-        // Filter out invalid entries (non-strings, empty strings, whitespace-only strings)
-        // DEFENSIVE PROGRAMMING: Validates each term before API calls to prevent:
-        // 1. Runtime errors from non-string values
-        // 2. Wasted API quota on queries that Google would reject
-        // 3. Confusing error messages from invalid search parameters
-        const validSearchTerms = uniqueTerms.filter(term => typeof term === 'string' && term.trim() !== '');
+        // Remove duplicates after trimming and lower-casing
+        // UPDATED STRATEGY: Normalizes terms to avoid redundant requests for "A" vs " a " vs "a"
+        // while preserving the original order of the first normalized occurrence.
+        const seen = new Set(); //track normalized terms for deduping
+        const validSearchTerms = []; //store final sanitized terms
+        for (const term of searchTerms) {
+                if (typeof term !== 'string') { continue; } //skip non-strings early
+                const trimmed = term.trim(); //remove leading/trailing whitespace
+                if (trimmed === '') { continue; } //ignore empty after trim
+                const norm = trimmed.toLowerCase(); //case-insensitive key for dedup
+                if (!seen.has(norm)) { //only first occurrence allowed
+                        seen.add(norm); //mark normalized term as seen
+                        validSearchTerms.push(trimmed); //store trimmed term for search
+                }
+        }
         
         if (validSearchTerms.length === 0) {
                 logWarn('No valid search terms provided'); //warn about empty input


### PR DESCRIPTION
## Summary
- improve search term dedupe to trim & lower case before comparison
- test that similar queries differing only by spacing and case hit the API once

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6850d5129b948322861edd3792725bf5