### PR TITLE
Preserve error name in axios handler

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -116,6 +116,15 @@ test('handleAxiosError passes sanitized error to qerrors', async () => { //verif
   expect(arg.stack).toBe(err.stack); //stack should be retained on sanitized copy
 });
 
+test('handleAxiosError passes original error name to qerrors', async () => { //verify preserved name
+  const { handleAxiosError } = require('../lib/qserp'); //import function
+  const err = new Error('named');
+  err.name = 'NamedError';
+  await handleAxiosError(err, 'ctx');
+  const arg = qerrorsMock.mock.calls[0][0];
+  expect(arg.name).toBe('NamedError'); //sanitized error keeps original name
+});
+
 test('handleAxiosError returns false when qerrors throws', async () => { //verify fallback on qerrors failure
   const { handleAxiosError } = require('../lib/qserp'); //load function under test
   const err = new Error('bad'); //mock basic error

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -305,6 +305,7 @@ async function handleAxiosError(error, contextMsg) { //async to await qerrors re
 
                 const sanitized = Object.assign(new Error(), errObj); //clone properties into new Error object
                 sanitized.message = sanitizeApiKey(errObj.message); //overwrite message with sanitized value
+                sanitized.name = errObj.name || 'Error'; //preserves error context for qerrors
                 if (errObj.stack) { sanitized.stack = errObj.stack; } //retain original stack when provided
                 if (errObj && errObj.config && errObj.config.url) { //check for config before copy
                         sanitized.config = { ...errObj.config, url: sanitizeApiKey(errObj.config.url) }; //sanitize url field


### PR DESCRIPTION
## Summary
- keep the original error name when sanitizing in `handleAxiosError`
- test that the error name is forwarded to `qerrors`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6850d4f59c0c8322a7ee34c6f73b74f4