### PR TITLE
Improve API key sanitization in qerrorsLoader

### DIFF
--- a/__tests__/qerrorsLoader.test.js
+++ b/__tests__/qerrorsLoader.test.js
@@ -130,3 +130,18 @@ describe('safeQerrors', () => { //new tests for sanitized logging
     expect(result).toBe(false); //should return false rather than throw
   });
 });
+
+describe('sanitizeApiKey', () => { //verify key masking logic
+  test('keeps words containing key intact', () => { //word with key should remain
+    const savedKey = process.env.GOOGLE_API_KEY; //save environment key
+    process.env.GOOGLE_API_KEY = 'key'; //set predictable key for test
+    jest.resetModules(); //reload module with new key
+    let sanitizeApiKey;
+    jest.isolateModules(() => { //isolate to avoid cache interference
+      ({ sanitizeApiKey } = require('../lib/qerrorsLoader')); //import function
+    });
+    const result = sanitizeApiKey('monkey key keyhole'); //call sanitizer
+    expect(result).toBe('monkey [redacted] keyhole'); //only actual key masked
+    if (savedKey !== undefined) { process.env.GOOGLE_API_KEY = savedKey; } else { delete process.env.GOOGLE_API_KEY; } //restore key
+  });
+});

--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -13,13 +13,52 @@
 const { logStart, logReturn } = require('./logUtils'); //import standardized logging utilities
 const { logError } = require('./minLogger'); //import error logging utility
 
-// Simple sanitizer to mask any instance of the Google API key in a string
-function sanitizeApiKey(text) { //avoid leaking sensitive key in logs
-        const key = process.env.GOOGLE_API_KEY; //retrieve current key from env
-        const sanitized = key ? String(text).split(key).join('[redacted]') : String(text); //replace key with placeholder
-        logStart('sanitizeApiKey', sanitized); //trace sanitized input for debug
-        logReturn('sanitizeApiKey', sanitized); //trace sanitized output for debug
-        return sanitized; //return sanitized string to caller
+// Sanitizes strings by masking the API key wherever it appears
+function sanitizeApiKey(text) { //prevent leaking key values in logs
+        let result; //value after sanitization for return logging
+        let sanitizedInput; //intermediate mutated string
+        try {
+                const key = process.env.GOOGLE_API_KEY; //read current key
+                const escKey = key ? key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape regex metachars
+                const rawParamRegex = key ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //match ?a=key
+                const encEscKey = key ? encodeURIComponent(key).replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape encoded key
+                const encValueRegex = key ? new RegExp(`([?&][^=&]*=)${encEscKey}`, 'g') : null; //match ?a=encodedKey
+                const encParamRegex = key ? new RegExp(`([?&][^=&]*%3D)${encEscKey}`, 'gi') : null; //match ?a%3DencodedKey
+                const plainRegex = key ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //standalone key only
+
+                sanitizedInput = String(text); //normalize input type
+                if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //mask raw param value
+                if (encValueRegex) sanitizedInput = sanitizedInput.replace(encValueRegex, '$1[redacted]'); //mask encoded value
+                if (encParamRegex) sanitizedInput = sanitizedInput.replace(encParamRegex, '$1[redacted]'); //mask encoded '=' form
+                if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //mask standalone key
+                logStart('sanitizeApiKey', sanitizedInput); //log sanitized input
+                result = sanitizedInput; //capture sanitized result
+        } catch (err) { //fallback when regex building fails
+                const key = process.env.GOOGLE_API_KEY; //re-read key for fallback
+                const escKey = key ? key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape again for regex
+                const rawParamRegex = key ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //fallback raw regex
+                let encValueRegex; //placeholders for encoded regexes
+                let encParamRegex;
+                try {
+                        const encEscKey = key ? encodeURIComponent(key).replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape encoded key
+                        encValueRegex = key ? new RegExp(`([?&][^=&]*=)${encEscKey}`, 'g') : null; //encoded value regex
+                        encParamRegex = key ? new RegExp(`([?&][^=&]*%3D)${encEscKey}`, 'gi') : null; //encoded '=' regex
+                } catch (e) {
+                        encValueRegex = null; //unable to build encoded regex
+                        encParamRegex = null; //unable to build encoded regex
+                }
+                const plainRegex = key ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //fallback plain regex
+
+                sanitizedInput = String(text); //ensure string to avoid errors
+                if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //mask raw value
+                if (encValueRegex) sanitizedInput = sanitizedInput.replace(encValueRegex, '$1[redacted]'); //mask encoded value
+                if (encParamRegex) sanitizedInput = sanitizedInput.replace(encParamRegex, '$1[redacted]'); //mask encoded '=' value
+                if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //mask plain occurrences
+                logStart('sanitizeApiKey', sanitizedInput); //log sanitized fallback
+                result = sanitizedInput; //use fallback sanitized string
+        }
+        logReturn('sanitizeApiKey', result); //log return value for traceability
+        return result; //provide sanitized string back to caller
 }
 
 /**
@@ -163,6 +202,7 @@ module.exports = function() {
 module.exports.loadQerrors = loadQerrors;       // Direct loader access
 module.exports.safeQerrors = safeQerrors;       // Safe wrapper with fallback
 module.exports.createCompatible = createCompatibleQerrors; // Explicit wrapper creation
+module.exports.sanitizeApiKey = sanitizeApiKey; // Export sanitizer for testing
 
 // Maintain backward compatibility with existing imports
 module.exports.default = module.exports;


### PR DESCRIPTION
## Summary
- sanitize API key in `qerrorsLoader` using regex logic from `qserp`
- export sanitizer for testing
- test that words containing the key remain intact

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6850d9a9e3808322a92d78cf41cc83a7