### PR TITLE
Update env variable checks for whitespace values

### DIFF
--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -61,6 +61,19 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
     expect(safeQerrors).toHaveBeenCalledTimes(1); //safeQerrors invoked once //(check)
   });
 
+  test('treats whitespace-only values as missing', () => { //verify whitespace handling //(new case)
+    const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('../lib/envUtils'); //require utils fresh
+    process.env.A = '   '; //set env A to whitespace only
+    process.env.B = 'val'; //define env B normally
+    expect(getMissingEnvVars(['A', 'B'])).toEqual(['A']); //should detect A as missing
+    expect(() => throwIfMissingEnvVars(['A', 'B'])).toThrow('Missing required'); //should throw on whitespace value
+    expect(warnIfMissingEnvVars(['A', 'B'], 'warn')).toBe(false); //should warn when whitespace present
+    expect(warnSpy).toHaveBeenCalledWith('warn'); //warn called with message
+    expect(errorSpy).toHaveBeenCalledWith('Missing required environment variables: A'); //error logged for A
+    expect(qerrors).not.toHaveBeenCalled(); //qerrors not used directly
+    expect(safeQerrors).toHaveBeenCalledTimes(1); //safeQerrors invoked once
+  });
+
   test('handles undefined variable array', () => { //verify undefined input //(third case)
     const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('../lib/envUtils'); //require utils fresh //(ensure env captured)
     expect(() => getMissingEnvVars(undefined)).toThrow(TypeError); //should throw when param invalid //(assert)

--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -33,7 +33,10 @@ function calcMissing(varArr) {
        }
 
        try { //attempt to filter normally without upfront checks to mimic prior behavior
-               const result = varArr.filter(name => !process.env[name]);
+               const result = varArr.filter(name => { //filter env vars, treat whitespace as missing
+                       const val = process.env[name]; //retrieve env var value for name
+                       return !val || val.trim() === ''; //flag missing when undefined or trimmed empty
+               });
                if (DEBUG) { logReturn('calcMissing', result); } //trace filtered list
                return result; //return computed array
        } catch (err) {


### PR DESCRIPTION
## Summary
- treat whitespace-only env vars as missing in calcMissing
- add tests for whitespace env var cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850d9b77f1c83229ceffb96d83b56c6