### PR TITLE
Improve minLogger handling of object messages

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -87,9 +87,10 @@ test('handleAxiosError logs sanitized response object and returns true', async (
   const spy = mockConsole('error'); //spy on console.error via helper
   const res = await handleAxiosError(err, 'ctx'); //call function with response error
   expect(res).toBe(true); //should return true
-  const logged = spy.mock.calls[0][0]; //capture logged object for inspection
-  expect(JSON.stringify(logged)).not.toContain('key=key'); //verify key removed from log
-  expect(logged.config.url).toBe('http://x?key=[redacted]'); //parameter name preserved
+  const logged = spy.mock.calls[0][0]; //capture logged string for inspection
+  expect(logged).not.toContain('key=key'); //verify key removed from log
+  const parsed = JSON.parse(logged); //parse JSON string back to object
+  expect(parsed.config.url).toBe('http://x?key=[redacted]'); //parameter name preserved
   spy.mockRestore(); //restore console.error
 });
 

--- a/__tests__/minLogger.test.js
+++ b/__tests__/minLogger.test.js
@@ -90,4 +90,14 @@ describe('minLogger', () => { // minLogger
     warnSpy.mockRestore(); //cleanup warn spy
     errorSpy.mockRestore(); //cleanup error spy
   });
+
+  test('logs object input as JSON string', () => { //object serialization check
+    process.env.LOG_LEVEL = 'warn'; //allow warnings
+    const spy = mockConsole('warn'); //spy console.warn
+    const { logWarn } = require('../lib/minLogger'); //import function
+    const obj = { a: 1 }; //sample object
+    logWarn(obj); //call logger with object
+    expect(spy).toHaveBeenCalledWith(JSON.stringify(obj)); //should log as string
+    spy.mockRestore(); //cleanup
+  });
 });

--- a/lib/minLogger.js
+++ b/lib/minLogger.js
@@ -23,6 +23,7 @@
 // This ordering ensures that error messages are shown in more restrictive
 // environments than warning messages, following standard logging practices
 const levelRank = { error: 0, warn: 1, info: 2, silent: 3 }; //rank map for levels
+const util = require('util'); //node util for inspect fallback
 
 // Check if info level logging is allowed for trace messages //rationale: avoid noisy logs when not needed
 function canLogInfo() {
@@ -83,6 +84,30 @@ function shouldLog(level) {
         }
 }
 
+// Formats any message into a readable string for logging //ensures objects are serialized
+function normalizeMsg(msg) {
+        if (shouldLog('info')) console.log(`normalizeMsg is running with ${msg}`); //trace start
+        try {
+                let formatted; //holder for output string
+                if (typeof msg === 'string') { //message already string
+                        formatted = msg; //no change needed
+                } else if (typeof msg === 'object') { //object requires serialization
+                        try {
+                                formatted = JSON.stringify(msg); //attempt JSON serialization
+                        } catch (jsonErr) {
+                                formatted = util.inspect(msg); //fallback to util.inspect
+                        }
+                } else {
+                        formatted = String(msg); //primitive conversion for numbers/booleans
+                }
+                if (shouldLog('info')) console.log(`normalizeMsg is returning ${formatted}`); //trace end
+                return formatted; //return processed string
+        } catch (err) {
+                if (shouldLog('info')) console.log(`normalizeMsg returning ${String(msg)}`); //trace failure fallback
+                return String(msg); //ensure string on failure
+        }
+}
+
 /**
  * Logs warning messages when LOG_LEVEL permits
  * 
@@ -104,7 +129,7 @@ function logWarn(msg) {
                 // Check if warning level is allowed by current LOG_LEVEL setting
                 // This delegation ensures consistent level handling across all log functions
                 if (shouldLog('warn')) { //respect LOG_LEVEL for warnings
-                        console.warn(msg); //emit warning when allowed
+                        console.warn(normalizeMsg(msg)); //serialize message before warn
                 }
                 if (shouldLog('info')) console.log(`logWarn is returning true`); //trace successful end when allowed
                 return true; //confirm execution
@@ -137,7 +162,7 @@ function logError(msg) {
                 // Check if error level is allowed (should be true unless LOG_LEVEL='silent')
                 // This maintains consistency with the level checking pattern
                 if (shouldLog('error')) { //respect LOG_LEVEL for errors
-                        console.error(msg); //emit error when allowed
+                        console.error(normalizeMsg(msg)); //serialize message before error
                 }
                 if (shouldLog('info')) console.log(`logError is returning true`); //trace successful end when allowed
                 return true; //confirm execution


### PR DESCRIPTION
## Summary
- serialize non-string messages in `logWarn` and `logError`
- add object serialization helper `normalizeMsg`
- adjust object handling tests
- test logging objects through `minLogger`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6850d9ae6d0c83228216705cf2d0a73f