### PR TITLE
Fix reportError sanitization

### DIFF
--- a/lib/errorUtils.js
+++ b/lib/errorUtils.js
@@ -19,6 +19,7 @@
 
 const { safeQerrors } = require('./qerrorsLoader'); //import safe wrapper for qerrors
 const { logStart, logReturn } = require('./logUtils'); //logging utilities for tracing
+const { sanitizeApiKey } = require('./qserp'); //sanitize sensitive info before logging
 
 /**
  * Creates standardized error context for API/network operations
@@ -116,8 +117,8 @@ async function reportError(error, message, context = {}, customDetails = {}) {
                 logReturn('reportError', 'success'); //trace success only when result is not false
                 return true; //indicate handled
         } catch (reportingError) {
-                console.error('Error reporting failed:', reportingError); //fallback log
-                console.error('Original error:', error);
+                console.error('Error reporting failed:', sanitizeApiKey(reportingError)); //mask sensitive data in reporting error
+                console.error('Original error:', sanitizeApiKey(error)); //mask sensitive data in original error
                 logReturn('reportError', 'failure'); //trace failure
                 return false; //indicate failure
         }


### PR DESCRIPTION
## Summary
- sanitize logged errors in `reportError`
- update fallback log expectations in tests
- mock qerrorsLoader default for qserp import
- ensure CODEX mode for test isolation
- add test for sanitized logging on failure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850d9a0ea848322b17778b70fa98a14