### PR TITLE
Fix caching of empty results

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -148,6 +148,17 @@ describe('qserp module', () => { //group qserp tests
     expect(scheduleMock).toHaveBeenCalled(); //new request scheduled
   });
 
+  test('fetchSearchItems caches empty results', async () => { //verify empty array cached
+    mock.onGet(/EmptyCache/).reply(200, { items: [] }); //mock no results response
+    const first = await fetchSearchItems('EmptyCache'); //populate cache with empty array
+    scheduleMock.mockClear(); //reset counter before second call
+    mock.onGet(/EmptyCache/).reply(200, { items: [{ link: 'x' }] }); //would be new data if fetched again
+    const second = await fetchSearchItems('EmptyCache'); //should use cached empty array
+    expect(first).toEqual([]); //first call returns empty array
+    expect(second).toEqual([]); //second call should also return cached empty array
+    expect(scheduleMock).not.toHaveBeenCalled(); //no second request due to cache
+  });
+
   test('CODEX mode does not populate cache', async () => { //verify mock results are not cached
     process.env.CODEX = 'true'; //enable offline mode
     const first = await fetchSearchItems('NoCache'); //call with codex enabled

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -432,7 +432,7 @@ async function fetchSearchItems(query, num) { //accept optional num for result c
                let cachedItems;
                if (MAX_CACHE_SIZE !== 0) { //skip cache when disabled
                        cachedItems = cache.get(cacheKey); //lookup existing cache entry with automatic TTL handling
-                       if (cachedItems) { //check if entry exists and hasn't expired
+                       if (cachedItems !== undefined) { //treat empty arrays as valid cache results
                                if (DEBUG) { console.log('fetchSearchItems returning cached'); } //(log cache hit)
                                logReturn('fetchSearchItems', JSON.stringify(cachedItems)); //(log cached return)
                                return cachedItems; //use cached array


### PR DESCRIPTION
## Summary
- treat empty arrays as cache hits in `fetchSearchItems`
- test caching behavior when a query returns no items

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6850d99ccd38832294c42b36c41f50a5