### PR TITLE
Fix Google URL builder credential omission

### DIFF
--- a/__tests__/internalFunctions.test.js
+++ b/__tests__/internalFunctions.test.js
@@ -73,6 +73,17 @@ test('getGoogleURL encodes key and cx values', () => { // getGoogleURL encodes k
   expect(url).toBe('https://customsearch.googleapis.com/customsearch/v1?q=encode&key=k%2B%2Fval&cx=cx%2F%2B&fields=items(title,snippet,link)'); //encoded key and cx
 });
 
+test('getGoogleURL omits credentials when absent in CODEX mode', () => { //verify undefined creds are skipped
+  delete process.env.GOOGLE_API_KEY; //remove key to simulate unset state
+  delete process.env.GOOGLE_CX; //remove cx for same reason
+  process.env.CODEX = 'true'; //enable codex to bypass env checks
+  jest.resetModules(); //reload module to read modified env
+  const { getGoogleURL } = require('../lib/qserp');
+  const url = getGoogleURL('noauth'); //build url without credentials
+  expect(url).toBe('https://customsearch.googleapis.com/customsearch/v1?q=noauth&fields=items(title,snippet,link)'); //should not contain key or cx params
+  delete process.env.CODEX; //cleanup to avoid affecting other tests
+});
+
 test('handleAxiosError logs with qerrors and returns true', async () => { // handleAxiosError logs with qerrors and returns true
   const { handleAxiosError } = require('../lib/qserp');
   const err = new Error('fail');

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -266,11 +266,14 @@ function getGoogleURL(query, num) { //accept optional num argument to limit resu
         // Construct base URL with required parameters and optimized field selection
         // FIELDS OPTIMIZATION: Only request title, snippet, link to reduce response payload
         // by ~50-70% compared to full response, improving network performance
-        const key = process.env.GOOGLE_API_KEY || defaultApiKey; //read env each call with fallback
-        const searchCx = process.env.GOOGLE_CX || defaultCx; //allow runtime override of cx
-        const encodedKey = encodeURIComponent(key); //url encode dynamic api key
-        const encodedCx = encodeURIComponent(searchCx); //url encode dynamic cx
-        const base = `https://customsearch.googleapis.com/customsearch/v1?q=${encodedQuery}&key=${encodedKey}&cx=${encodedCx}&fields=items(title,snippet,link)`; //update to current Google endpoint
+        const key = process.env.GOOGLE_API_KEY || defaultApiKey; //read env each call for dynamic credentials
+        const searchCx = process.env.GOOGLE_CX || defaultCx; //read cx each call for runtime updates
+
+        const params = [`q=${encodedQuery}`]; //start with encoded query in param list
+        if (key) { params.push(`key=${encodeURIComponent(key)}`); } //add key param only when defined to avoid undefined value
+        if (searchCx) { params.push(`cx=${encodeURIComponent(searchCx)}`); } //add cx param when provided for same reason
+        params.push('fields=items(title,snippet,link)'); //always request minimal fields for smaller response
+        const base = `https://customsearch.googleapis.com/customsearch/v1?${params.join('&')}`; //assemble base URL from params
 
         // Normalize num parameter to Google's allowed range 1-10
         // REUSE LOGIC: Delegates clamping to normalizeNum for consistency


### PR DESCRIPTION
## Summary
- handle missing GOOGLE_API_KEY and GOOGLE_CX in `getGoogleURL`
- test that CODEX mode omits undefined credentials

## Testing
- `npx jest --runInBand --json --outputFile=result.json >/dev/null 2>&1 && jq '{total:.numTotalTests,passed:.numPassedTests,failed:.numFailedTests}' result.json`

------
https://chatgpt.com/codex/tasks/task_b_6850f595d67c83229a5d33fb1796ac3b