### PR TITLE
Update sanitizer to handle original env key

### DIFF
--- a/__tests__/qserp.test.js
+++ b/__tests__/qserp.test.js
@@ -316,10 +316,11 @@ describe('qserp module', () => { //group qserp tests
     const { sanitizeApiKey } = require('../lib/qserp'); //load module with initial key
     logSpy.mockClear(); //ignore module logs
     process.env.GOOGLE_API_KEY = 'new'; //change key at runtime
-    const result = sanitizeApiKey('pre new post'); //call using new key
-    expect(result).toBe('pre [redacted] post'); //expect sanitized
-    expect(logSpy).toHaveBeenNthCalledWith(1, 'sanitizeApiKey is running with pre [redacted] post'); //input sanitized
-    expect(logSpy).toHaveBeenNthCalledWith(2, 'sanitizeApiKey is returning pre [redacted] post'); //output sanitized
+    const result = sanitizeApiKey('pre key new post'); //call including both keys
+    const joined = logSpy.mock.calls.map(c => c[0]).join(' '); //combine logs
+    expect(result).toBe('pre [redacted] [redacted] post'); //expect both keys masked
+    expect(joined).not.toMatch('key'); //old key removed from logs
+    expect(joined).not.toMatch('new'); //new key removed from logs
     logSpy.mockRestore(); //cleanup
     if (savedDebug !== undefined) { process.env.DEBUG = savedDebug; } else { delete process.env.DEBUG; } //restore debug
   });

--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -12,48 +12,53 @@
 
 const { logStart, logReturn } = require('./logUtils'); //import standardized logging utilities
 const { logError } = require('./minLogger'); //import error logging utility
+const defaultApiKey = process.env.GOOGLE_API_KEY; //initial key captured for later masking
 
 // Sanitizes strings by masking the API key wherever it appears
 function sanitizeApiKey(text) { //prevent leaking key values in logs
         let result; //value after sanitization for return logging
         let sanitizedInput; //intermediate mutated string
+        const applyPatterns = (str, key) => { //helper masks one key
+                if (!key) return str; //skip when key missing
+                try {
+                        const escKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); //escape metachars
+                        const rawParam = new RegExp(`([?&][^=&]*=)${escKey}`, 'g'); //raw param regex
+                        const encEscKey = encodeURIComponent(key).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); //escape encoded key
+                        const encValue = new RegExp(`([?&][^=&]*=)${encEscKey}`, 'g'); //encoded value regex
+                        const encParam = new RegExp(`([?&][^=&]*%3D)${encEscKey}`, 'gi'); //encoded '=' regex
+                        const plain = new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g'); //plain key regex
+                        return str
+                                .replace(rawParam, '$1[redacted]') //mask raw value
+                                .replace(encValue, '$1[redacted]') //mask encoded value
+                                .replace(encParam, '$1[redacted]') //mask encoded '=' value
+                                .replace(plain, '[redacted]'); //mask standalone key
+                } catch (e) { //fallback to simpler replacement on failure
+                        try {
+                                const escKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); //escape again safely
+                                let out = str.replace(new RegExp(`([?&][^=&]*=)${escKey}`, 'g'), '$1[redacted]'); //mask raw
+                                let encEscKey;
+                                try { encEscKey = encodeURIComponent(key).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); } catch (_) { encEscKey = null; }
+                                if (encEscKey) {
+                                        out = out.replace(new RegExp(`([?&][^=&]*=)${encEscKey}`, 'g'), '$1[redacted]'); //encoded value
+                                        out = out.replace(new RegExp(`([?&][^=&]*%3D)${encEscKey}`, 'gi'), '$1[redacted]'); //encoded '='
+                                }
+                                out = out.replace(new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g'), '[redacted]'); //plain key
+                                return out; //return sanitized fallback
+                        } catch (_) { return str; } //give up on error
+                }
+        };
         try {
-                const key = process.env.GOOGLE_API_KEY; //read current key
-                const escKey = key ? key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape regex metachars
-                const rawParamRegex = key ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //match ?a=key
-                const encEscKey = key ? encodeURIComponent(key).replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape encoded key
-                const encValueRegex = key ? new RegExp(`([?&][^=&]*=)${encEscKey}`, 'g') : null; //match ?a=encodedKey
-                const encParamRegex = key ? new RegExp(`([?&][^=&]*%3D)${encEscKey}`, 'gi') : null; //match ?a%3DencodedKey
-                const plainRegex = key ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //standalone key only
-
+                const envKey = process.env.GOOGLE_API_KEY; //current key
                 sanitizedInput = String(text); //normalize input type
-                if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //mask raw param value
-                if (encValueRegex) sanitizedInput = sanitizedInput.replace(encValueRegex, '$1[redacted]'); //mask encoded value
-                if (encParamRegex) sanitizedInput = sanitizedInput.replace(encParamRegex, '$1[redacted]'); //mask encoded '=' form
-                if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //mask standalone key
+                sanitizedInput = applyPatterns(sanitizedInput, envKey); //mask runtime key
+                if (defaultApiKey && defaultApiKey !== envKey) sanitizedInput = applyPatterns(sanitizedInput, defaultApiKey); //mask initial key when changed
                 logStart('sanitizeApiKey', sanitizedInput); //log sanitized input
                 result = sanitizedInput; //capture sanitized result
         } catch (err) { //fallback when regex building fails
-                const key = process.env.GOOGLE_API_KEY; //re-read key for fallback
-                const escKey = key ? key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape again for regex
-                const rawParamRegex = key ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //fallback raw regex
-                let encValueRegex; //placeholders for encoded regexes
-                let encParamRegex;
-                try {
-                        const encEscKey = key ? encodeURIComponent(key).replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape encoded key
-                        encValueRegex = key ? new RegExp(`([?&][^=&]*=)${encEscKey}`, 'g') : null; //encoded value regex
-                        encParamRegex = key ? new RegExp(`([?&][^=&]*%3D)${encEscKey}`, 'gi') : null; //encoded '=' regex
-                } catch (e) {
-                        encValueRegex = null; //unable to build encoded regex
-                        encParamRegex = null; //unable to build encoded regex
-                }
-                const plainRegex = key ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //fallback plain regex
-
+                const envKey = process.env.GOOGLE_API_KEY; //re-read on failure
                 sanitizedInput = String(text); //ensure string to avoid errors
-                if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //mask raw value
-                if (encValueRegex) sanitizedInput = sanitizedInput.replace(encValueRegex, '$1[redacted]'); //mask encoded value
-                if (encParamRegex) sanitizedInput = sanitizedInput.replace(encParamRegex, '$1[redacted]'); //mask encoded '=' value
-                if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //mask plain occurrences
+                sanitizedInput = applyPatterns(sanitizedInput, envKey); //mask runtime key
+                if (defaultApiKey && defaultApiKey !== envKey) sanitizedInput = applyPatterns(sanitizedInput, defaultApiKey); //mask initial key again
                 logStart('sanitizeApiKey', sanitizedInput); //log sanitized fallback
                 result = sanitizedInput; //use fallback sanitized string
         }

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -42,8 +42,8 @@ const axiosInstance = axios.create({ //axios instance with keepAlive agents and 
        httpsAgent: new https.Agent({ keepAlive: true, maxSockets: 20, maxFreeSockets: 10 }) //reuse https sockets with connection limits
 });
 const Bottleneck = require('bottleneck'); // Rate limiting library to prevent API quota exhaustion
-const defaultApiKey = process.env.GOOGLE_API_KEY; // initial api key fallback when env changes
-const defaultCx = process.env.GOOGLE_CX; // initial cx fallback when env changes
+const defaultApiKey = process.env.GOOGLE_API_KEY; //initial key captured for masking old values
+const defaultCx = process.env.GOOGLE_CX; //initial cx captured for fallback when env changes
 const { getDebugFlag } = require('./getDebugFlag'); //import debug flag utility for consistent behavior
 const DEBUG = getDebugFlag(); //flag to toggle verbose logging
 
@@ -91,47 +91,55 @@ const { logWarn, logError } = require('./minLogger'); //minimal log utility for 
 function sanitizeApiKey(text) { //mask api key values without altering param names
         let result; //final sanitized value holder
         let sanitizedInput; //input sanitized only for logging
-        try {
-                const currentKey = process.env.GOOGLE_API_KEY || defaultApiKey; //read current key each call
-                const escKey = currentKey ? currentKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape regex metachars
-                const rawParamRegex = currentKey ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //match key after '=' to keep name
-                const encEscKey = currentKey ? encodeURIComponent(currentKey).replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape encoded key for regex
-                const encValueRegex = currentKey ? new RegExp(`([?&][^=&]*=)${encEscKey}`, 'g') : null; //match encoded value without encoded '=' using escaped key
-                const encParamRegex = currentKey ? new RegExp(`([?&][^=&]*%3D)${encEscKey}`, 'gi') : null; //match encoded '=' forms using escaped key
-                const plainRegex = currentKey ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //match standalone key not followed by '='
-
-                sanitizedInput = String(text); //normalize to string for safe replace calls
-
-                if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //replace param value only
-                if (encValueRegex) sanitizedInput = sanitizedInput.replace(encValueRegex, '$1[redacted]'); //replace encoded value without encoded '='
-                if (encParamRegex) sanitizedInput = sanitizedInput.replace(encParamRegex, '$1[redacted]'); //replace encoded param value
-                if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //replace standalone key
-                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //trace sanitized input
-                result = sanitizedInput; //use sanitized version as result
-        } catch (err) {
-                const currentKey = process.env.GOOGLE_API_KEY || defaultApiKey; //re-read on failure
-                const escKey = currentKey ? currentKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape for fallback regex
-                const rawParamRegex = currentKey ? new RegExp(`([?&][^=&]*=)${escKey}`, 'g') : null; //fallback param regex
-                let encValueRegex; //encoded value regex placeholder
-                let encParamRegex; //encoded param regex placeholder
-                try { //attempt to build encoded regex even after failure
-                        const encEscKey = currentKey ? encodeURIComponent(currentKey).replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : ''; //escape encoded key
-                        encValueRegex = currentKey ? new RegExp(`([?&][^=&]*=)${encEscKey}`, 'g') : null; //regex for encoded value
-                        encParamRegex = currentKey ? new RegExp(`([?&][^=&]*%3D)${encEscKey}`, 'gi') : null; //regex for encoded '=' form
-                } catch (e) {
-                        encValueRegex = null; //fallback to no encoded replacement when encode fails
-                        encParamRegex = null; //fallback to no encoded replacement when encode fails
+        const applyPatterns = (str, key) => { //helper applies regex set for one key
+                if (!key) return str; //skip when no key provided
+                try {
+                        const escKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); //escape regex metachars
+                        const rawParamRegex = new RegExp(`([?&][^=&]*=)${escKey}`, 'g'); //match key after '='
+                        const encEscKey = encodeURIComponent(key).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); //escape encoded key
+                        const encValueRegex = new RegExp(`([?&][^=&]*=)${encEscKey}`, 'g'); //match encoded value
+                        const encParamRegex = new RegExp(`([?&][^=&]*%3D)${encEscKey}`, 'gi'); //match encoded '=' param
+                        const plainRegex = new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g'); //match standalone key
+                        let out = str; //mutable result string
+                        out = out.replace(rawParamRegex, '$1[redacted]'); //mask raw parameter
+                        out = out.replace(encValueRegex, '$1[redacted]'); //mask encoded value
+                        out = out.replace(encParamRegex, '$1[redacted]'); //mask encoded '=' value
+                        out = out.replace(plainRegex, '[redacted]'); //mask standalone occurrence
+                        return out; //return masked string
+                } catch (e) { //fallback when regex creation fails
+                        try {
+                                const escKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); //escape again for safety
+                                const rawParamRegex = new RegExp(`([?&][^=&]*=)${escKey}`, 'g'); //raw param
+                                let out = str.replace(rawParamRegex, '$1[redacted]'); //mask raw param
+                                let encEscKey;
+                                try { encEscKey = encodeURIComponent(key).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); } catch (_) { encEscKey = null; } //attempt encode
+                                if (encEscKey) {
+                                        out = out.replace(new RegExp(`([?&][^=&]*=)${encEscKey}`, 'g'), '$1[redacted]'); //mask encoded value
+                                        out = out.replace(new RegExp(`([?&][^=&]*%3D)${encEscKey}`, 'gi'), '$1[redacted]'); //mask encoded '=' value
+                                }
+                                out = out.replace(new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g'), '[redacted]'); //mask plain
+                                return out; //return sanitized fallback
+                        } catch (_) { return str; } //on repeated failure, return unchanged
                 }
-                const plainRegex = currentKey ? new RegExp(`\\b${escKey}\\b(?!\\s*=)`, 'g') : null; //fallback plain regex
-
-                sanitizedInput = String(text); //convert to string so replace never fails
-
-                if (rawParamRegex) sanitizedInput = sanitizedInput.replace(rawParamRegex, '$1[redacted]'); //mask value portion
-                if (encValueRegex) sanitizedInput = sanitizedInput.replace(encValueRegex, '$1[redacted]'); //mask encoded value
-                if (encParamRegex) sanitizedInput = sanitizedInput.replace(encParamRegex, '$1[redacted]'); //mask encoded '=' value
-                if (plainRegex) sanitizedInput = sanitizedInput.replace(plainRegex, '[redacted]'); //mask plain occurrences
-                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //trace fallback
-                result = sanitizedInput; //return sanitized fallback
+        };
+        try {
+                const envKey = process.env.GOOGLE_API_KEY; //read runtime key each call
+                sanitizedInput = String(text); //normalize input to string
+                sanitizedInput = applyPatterns(sanitizedInput, envKey); //mask env key
+                if (defaultApiKey && defaultApiKey !== envKey) { //mask initial key when different
+                        sanitizedInput = applyPatterns(sanitizedInput, defaultApiKey); //apply second key patterns
+                }
+                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //trace sanitized input
+                result = sanitizedInput; //capture result after masking
+        } catch (err) { //retry with catch logic when failure occurs
+                const envKey = process.env.GOOGLE_API_KEY; //re-read runtime key
+                sanitizedInput = String(text); //stringify fallback
+                sanitizedInput = applyPatterns(sanitizedInput, envKey); //mask env key
+                if (defaultApiKey && defaultApiKey !== envKey) {
+                        sanitizedInput = applyPatterns(sanitizedInput, defaultApiKey); //mask initial key again
+                }
+                if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //trace sanitized fallback
+                result = sanitizedInput; //use fallback sanitized result
         }
         if (DEBUG) { console.log(`sanitizeApiKey is returning ${result}`); } //final sanitized result log
         return result; //return sanitized string


### PR DESCRIPTION
## Summary
- sanitize both initial and current API keys in qserp
- sanitize both initial and current API keys in qerrorsLoader
- check logs for old and new keys after environment changes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_685119f5fb108322b522cb7098ad2cb9