### PR TITLE
Ensure debugUtils mocked before dependent imports

### DIFF
--- a/__tests__/envValidator.test.js
+++ b/__tests__/envValidator.test.js
@@ -1,15 +1,16 @@
+// Mock debugUtils before requiring any modules that depend on it
+jest.mock('../lib/debugUtils'); //ensures debug calls are intercepted
+
 // Summary: envValidator.test.js validates module behavior and edge cases
 /**
  * envValidator.test.js - Comprehensive unit tests for environment variable validation
- * 
+ *
  * Tests the centralized environment variable parsing and validation utilities
  * that provide secure bounds checking and type conversion across the codebase.
  */
 
-// Mock dependencies first so envValidator loads with mocked debug utilities
-jest.mock('../lib/debugUtils'); //ensure debug utils mocked before module import
-
-const { saveEnv, restoreEnv } = require('./utils/testSetup'); //env helpers for isolation
+let saveEnv; //helper loaded after modules reset
+let restoreEnv; //helper loaded after modules reset
 
 let parseIntWithBounds; //function loaded after reset
 let parseBooleanVar; //function loaded after reset
@@ -25,6 +26,7 @@ describe('envValidator', () => { // envValidator
         jest.resetModules(); //reload modules so mocks apply correctly
         ({ debugEntry, debugExit } = require('../lib/debugUtils')); //get mocked utils after reset
         ({ parseIntWithBounds, parseBooleanVar, parseStringVar, validateEnvVar } = require('../lib/envValidator')); //load functions under test
+        ({ saveEnv, restoreEnv } = require('./utils/testSetup')); //reload helpers using mocked debug utils
 
         savedEnv = saveEnv(); //capture environment state
         jest.clearAllMocks(); //reset mocks

--- a/__tests__/parseStringVar.test.js
+++ b/__tests__/parseStringVar.test.js
@@ -1,15 +1,16 @@
+// Mock debugUtils before loading any modules that depend on it
+jest.mock('../lib/debugUtils'); //ensures debug calls are tracked correctly
+
 // Summary: parseStringVar.test.js validates module behavior and edge cases
 /**
  * parseStringVar.test.js - Additional unit tests for string parsing functionality
- * 
+ *
  * Tests the parseStringVar and validateEnvVar functions from envValidator
  * to ensure comprehensive coverage of string validation scenarios.
  */
 
-// Mock dependencies first so envValidator uses the mocked debug utils
-jest.mock('../lib/debugUtils'); //ensure debug utilities mocked before module load
-
-const { saveEnv, restoreEnv } = require('./utils/testSetup'); //import env helpers
+let saveEnv; //helper loaded after modules reset
+let restoreEnv; //helper loaded after modules reset
 
 let parseStringVar; //function reference loaded after modules reset
 let validateEnvVar; //function reference loaded after modules reset
@@ -23,6 +24,7 @@ describe('parseStringVar', () => { // parseStringVar
         jest.resetModules(); //reload modules so mocks apply correctly
         ({ debugEntry, debugExit } = require('../lib/debugUtils')); //obtain mocked utils after reset
         ({ parseStringVar, validateEnvVar } = require('../lib/envValidator')); //load functions under test
+        ({ saveEnv, restoreEnv } = require('./utils/testSetup')); //reload helpers using mocked debug utils
 
         savedEnv = saveEnv(); //capture current env using util
         jest.clearAllMocks(); //reset mocks


### PR DESCRIPTION
## Summary
- mock debugUtils before loading helpers in envValidator and parseStringVar tests
- reload helpers after resetting modules so mocks remain active

## Testing
- `./node_modules/.bin/jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_b_6851c573f1948322ac344fc30f7dd91a