### PR TITLE
Implement DEBUG gating for qerrorsLoader sanitizer

### DIFF
--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -11,6 +11,7 @@
  */
 
 const { logStart, logReturn } = require('./logUtils'); //import standardized logging utilities
+const { DEBUG } = require('./debugUtils'); //import debug flag to gate verbose logs
 const { logError } = require('./minLogger'); //import error logging utility
 const defaultApiKey = process.env.GOOGLE_API_KEY; //initial key captured for later masking
 
@@ -52,17 +53,17 @@ function sanitizeApiKey(text) { //prevent leaking key values in logs
                 sanitizedInput = String(text); //normalize input type
                 sanitizedInput = applyPatterns(sanitizedInput, envKey); //mask runtime key
                 if (defaultApiKey && defaultApiKey !== envKey) sanitizedInput = applyPatterns(sanitizedInput, defaultApiKey); //mask initial key when changed
-                logStart('sanitizeApiKey', sanitizedInput); //log sanitized input
+                if (DEBUG) { logStart('sanitizeApiKey', sanitizedInput); } //log sanitized input only when debug enabled
                 result = sanitizedInput; //capture sanitized result
         } catch (err) { //fallback when regex building fails
                 const envKey = process.env.GOOGLE_API_KEY; //re-read on failure
                 sanitizedInput = String(text); //ensure string to avoid errors
                 sanitizedInput = applyPatterns(sanitizedInput, envKey); //mask runtime key
                 if (defaultApiKey && defaultApiKey !== envKey) sanitizedInput = applyPatterns(sanitizedInput, defaultApiKey); //mask initial key again
-                logStart('sanitizeApiKey', sanitizedInput); //log sanitized fallback
+                if (DEBUG) { logStart('sanitizeApiKey', sanitizedInput); } //log sanitized fallback when debug enabled
                 result = sanitizedInput; //use fallback sanitized string
         }
-        logReturn('sanitizeApiKey', result); //log return value for traceability
+        if (DEBUG) { logReturn('sanitizeApiKey', result); } //log return value when debug enabled
         return result; //provide sanitized string back to caller
 }
 


### PR DESCRIPTION
## Summary
- only log sanitizeApiKey when DEBUG flag is true
- test qerrorsLoader sanitizeApiKey logging behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6851f6215f3c8322bfdba240f0923d4e