### PR TITLE
Handle old api key

### DIFF
--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -17,7 +17,6 @@ const defaultApiKey = process.env.GOOGLE_API_KEY; //initial key captured for lat
 // Sanitizes strings by masking the API key wherever it appears
 function sanitizeApiKey(text) { //prevent leaking key values in logs
         let result; //value after sanitization for return logging
-        let sanitizedInput; //intermediate mutated string
         const applyPatterns = (str, key) => { //helper masks one key
                 if (!key) return str; //skip when key missing
                 try {
@@ -47,18 +46,21 @@ function sanitizeApiKey(text) { //prevent leaking key values in logs
                         } catch (_) { return str; } //give up on error
                 }
         };
-        try {
+        const maskKeys = value => { //apply patterns for current and initial keys sequentially
+                let out = String(value); //ensure string for replacement
                 const envKey = process.env.GOOGLE_API_KEY; //current key
-                sanitizedInput = String(text); //normalize input type
-                sanitizedInput = applyPatterns(sanitizedInput, envKey); //mask runtime key
-                if (defaultApiKey && defaultApiKey !== envKey) sanitizedInput = applyPatterns(sanitizedInput, defaultApiKey); //mask initial key when changed
+                const keys = []; //keys to mask
+                if (envKey) keys.push(envKey); //mask current key when present
+                if (defaultApiKey && defaultApiKey !== envKey) keys.push(defaultApiKey); //mask initial key when changed
+                for (const k of keys) out = applyPatterns(out, k); //apply patterns sequentially
+                return out; //return sanitized output
+        };
+        try {
+                const sanitizedInput = maskKeys(text); //sanitize using helper
                 logStart('sanitizeApiKey', sanitizedInput); //log sanitized input
                 result = sanitizedInput; //capture sanitized result
         } catch (err) { //fallback when regex building fails
-                const envKey = process.env.GOOGLE_API_KEY; //re-read on failure
-                sanitizedInput = String(text); //ensure string to avoid errors
-                sanitizedInput = applyPatterns(sanitizedInput, envKey); //mask runtime key
-                if (defaultApiKey && defaultApiKey !== envKey) sanitizedInput = applyPatterns(sanitizedInput, defaultApiKey); //mask initial key again
+                const sanitizedInput = maskKeys(text); //retry sanitization
                 logStart('sanitizeApiKey', sanitizedInput); //log sanitized fallback
                 result = sanitizedInput; //use fallback sanitized string
         }

--- a/lib/qserp.js
+++ b/lib/qserp.js
@@ -90,7 +90,6 @@ const { logWarn, logError } = require('./minLogger'); //minimal log utility for 
  */
 function sanitizeApiKey(text) { //mask api key values without altering param names
         let result; //final sanitized value holder
-        let sanitizedInput; //input sanitized only for logging
         const applyPatterns = (str, key) => { //helper applies regex set for one key
                 if (!key) return str; //skip when no key provided
                 try {
@@ -122,22 +121,21 @@ function sanitizeApiKey(text) { //mask api key values without altering param nam
                         } catch (_) { return str; } //on repeated failure, return unchanged
                 }
         };
-        try {
+        const maskKeys = value => { //apply patterns for env and initial keys sequentially
+                let out = String(value); //ensure string for replacement
                 const envKey = process.env.GOOGLE_API_KEY; //read runtime key each call
-                sanitizedInput = String(text); //normalize input to string
-                sanitizedInput = applyPatterns(sanitizedInput, envKey); //mask env key
-                if (defaultApiKey && defaultApiKey !== envKey) { //mask initial key when different
-                        sanitizedInput = applyPatterns(sanitizedInput, defaultApiKey); //apply second key patterns
-                }
+                const keys = []; //list of keys to mask
+                if (envKey) keys.push(envKey); //always mask current key
+                if (defaultApiKey && defaultApiKey !== envKey) keys.push(defaultApiKey); //mask initial key when changed
+                for (const k of keys) out = applyPatterns(out, k); //apply patterns per key
+                return out; //return masked string
+        };
+        try {
+                const sanitizedInput = maskKeys(text); //sanitize with helper
                 if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //trace sanitized input
                 result = sanitizedInput; //capture result after masking
         } catch (err) { //retry with catch logic when failure occurs
-                const envKey = process.env.GOOGLE_API_KEY; //re-read runtime key
-                sanitizedInput = String(text); //stringify fallback
-                sanitizedInput = applyPatterns(sanitizedInput, envKey); //mask env key
-                if (defaultApiKey && defaultApiKey !== envKey) {
-                        sanitizedInput = applyPatterns(sanitizedInput, defaultApiKey); //mask initial key again
-                }
+                const sanitizedInput = maskKeys(text); //retry sanitization
                 if (DEBUG) { console.log(`sanitizeApiKey is running with ${sanitizedInput}`); } //trace sanitized fallback
                 result = sanitizedInput; //use fallback sanitized result
         }


### PR DESCRIPTION
## Summary
- sanitize API keys using initial and current env keys
- apply masking sequentially when keys differ
- test log output for replaced keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6851c56d655083228ef6db7102489edd