### PR TITLE
Improve comments around env isolation in tests

### DIFF
--- a/__tests__/cacheSizeParsing.test.js
+++ b/__tests__/cacheSizeParsing.test.js
@@ -6,13 +6,13 @@ const { saveEnv, restoreEnv, setTestEnv } = require('./utils/testSetup'); // hel
 let savedEnv;
 
 beforeEach(() => {
-  savedEnv = saveEnv(); // store current env to keep tests isolated
-  jest.resetModules(); // clear module cache so env changes take effect
+  savedEnv = saveEnv(); // capture env snapshot so modifications don't leak to other tests
+  jest.resetModules(); // clear module cache so env changes apply to reloaded modules
 });
 
 afterEach(() => {
-  restoreEnv(savedEnv); // restore original env after each test
-  jest.resetModules(); // reset modules so next test has clean state
+  restoreEnv(savedEnv); // restore original env to prevent cross-test contamination
+  jest.resetModules(); // reset modules so the next test gets a clean instance
 });
 
 

--- a/__tests__/createCacheKey.test.js
+++ b/__tests__/createCacheKey.test.js
@@ -17,7 +17,7 @@ describe('createCacheKey', () => {
   });
 
   afterEach(() => { //restore env and spies
-    teardown();
+    teardown(); // restores env vars and console spies to avoid cross-test contamination
   });
 
   test('trims and lowercases query without num', () => { //verify base normalization

--- a/__tests__/debugUtils.simple.test.js
+++ b/__tests__/debugUtils.simple.test.js
@@ -12,15 +12,15 @@ describe('debugUtils functionality', () => { // debugUtils functionality
 
     beforeEach(() => {
         consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-        originalDebug = process.env.DEBUG;
+        originalDebug = process.env.DEBUG; // remember debug flag so we can restore after test
     });
 
     afterEach(() => {
         consoleSpy.mockRestore();
         if (originalDebug !== undefined) {
-            process.env.DEBUG = originalDebug;
+            process.env.DEBUG = originalDebug; // restore original flag for isolation
         } else {
-            delete process.env.DEBUG;
+            delete process.env.DEBUG; // ensure env var removal mirrors original state
         }
         jest.resetModules();
     });

--- a/__tests__/debugUtils.test.js
+++ b/__tests__/debugUtils.test.js
@@ -18,7 +18,7 @@ describe('debugUtils', () => { // debugUtils
         consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
 
         // Save original environment
-        originalEnv = process.env.DEBUG;
+        originalEnv = process.env.DEBUG; // preserve DEBUG so changes don't affect other tests
 
         // Clear module cache to ensure fresh imports
         jest.resetModules();
@@ -31,9 +31,9 @@ describe('debugUtils', () => { // debugUtils
         
         // Restore original environment
         if (originalEnv !== undefined) {
-            process.env.DEBUG = originalEnv;
+            process.env.DEBUG = originalEnv; // restore DEBUG to its prior value
         } else {
-            delete process.env.DEBUG;
+            delete process.env.DEBUG; // remove DEBUG entirely if it was unset
         }
     });
 

--- a/__tests__/envUtils.test.js
+++ b/__tests__/envUtils.test.js
@@ -10,7 +10,7 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
 
   let savedEnv; //holder for env snapshot //(for restoration)
   beforeEach(() => { //prepare each test //(reset env and mocks)
-    savedEnv = saveEnv(); //capture current env //(using util)
+    savedEnv = saveEnv(); // capture env to restore later so tests remain independent
     jest.resetModules(); //reload modules so env vars re-evaluated //(ensures clean require)
     jest.doMock('../lib/qerrorsLoader', () => { //mock qerrors loader per test
       const mockFn = jest.fn(); //placeholder qerrors function
@@ -28,7 +28,7 @@ describe('envUtils', () => { //wrap all env util tests //(use describe as reques
   });
 
   afterEach(() => { //cleanup after each test //(restore settings)
-    restoreEnv(savedEnv); //reset environment after test //(using util)
+    restoreEnv(savedEnv); // restore environment to prevent cross-test contamination
     warnSpy.mockRestore(); //restore logWarn spy //(remove spy)
     errorSpy.mockRestore(); //restore logError spy //(remove spy)
     jest.clearAllMocks(); //clear any mock usage //(reset mock counts)

--- a/__tests__/envValidator.test.js
+++ b/__tests__/envValidator.test.js
@@ -28,12 +28,12 @@ describe('envValidator', () => { // envValidator
         ({ parseIntWithBounds, parseBooleanVar, parseStringVar, validateEnvVar } = require('../lib/envValidator')); //load functions under test
         ({ saveEnv, restoreEnv } = require('./utils/testSetup')); //reload helpers using mocked debug utils
 
-        savedEnv = saveEnv(); //capture environment state
+        savedEnv = saveEnv(); // snapshot env so each test starts with same configuration
         jest.clearAllMocks(); //reset mocks
     });
 
     afterEach(() => {
-        restoreEnv(savedEnv); //restore environment state
+        restoreEnv(savedEnv); // restore env to ensure no pollution between tests
     });
 
     describe('parseIntWithBounds', () => { // parseIntWithBounds

--- a/__tests__/errorUtils.test.js
+++ b/__tests__/errorUtils.test.js
@@ -19,7 +19,7 @@ describe('errorUtils', () => { // errorUtils
     let savedCodex;
 
     beforeEach(() => {
-        savedCodex = process.env.CODEX; //preserve offline flag
+        savedCodex = process.env.CODEX; // record current CODEX so we can restore it
         process.env.CODEX = 'true'; //bypass env validation during module load
         // Spy on console.error for fallback logging tests
         consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -31,7 +31,7 @@ describe('errorUtils', () => { // errorUtils
 
     afterEach(() => {
         consoleErrorSpy.mockRestore();
-        if (savedCodex !== undefined) { process.env.CODEX = savedCodex; } else { delete process.env.CODEX; } //restore flag
+        if (savedCodex !== undefined) { process.env.CODEX = savedCodex; } else { delete process.env.CODEX; } //restore flag to avoid polluting other tests
     });
 
     describe('context creation functions', () => { // context creation functions

--- a/__tests__/getDebugFlag.test.js
+++ b/__tests__/getDebugFlag.test.js
@@ -14,12 +14,12 @@ describe('getDebugFlag', () => { // getDebugFlag
     let consoleSpy; //console spy for log assertions
 
     beforeEach(() => {
-        savedEnv = saveEnv(); //capture env using shared util
+        savedEnv = saveEnv(); // snapshot env so modifications in this test don't bleed into others
         consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {}); //stub console.log
     });
 
     afterEach(() => {
-        restoreEnv(savedEnv); //reset env after test using util
+        restoreEnv(savedEnv); // restore env to its original state to keep suites independent
         consoleSpy.mockRestore(); //restore console
     });
 

--- a/__tests__/memory-growth-analysis.test.js
+++ b/__tests__/memory-growth-analysis.test.js
@@ -8,7 +8,7 @@ describe('memory-growth-analysis script', () => {
   let logSpy;
 
   beforeEach(() => {
-    savedEnv = saveEnv(); //snapshot current environment
+    savedEnv = saveEnv(); // copy env so modifications during test can be undone
     setTestEnv(); //ensure required vars defined
     process.env.CODEX = 'true'; //offline mode avoids network requests
     jest.resetModules(); //reset module cache between tests
@@ -17,7 +17,7 @@ describe('memory-growth-analysis script', () => {
 
   afterEach(() => {
     logSpy.mockRestore();
-    restoreEnv(savedEnv);
+    restoreEnv(savedEnv); // restore saved environment to keep tests isolated
   });
 
   test('memoryGrowthAnalysis runs and logs completion', async () => {

--- a/__tests__/minLogger.test.js
+++ b/__tests__/minLogger.test.js
@@ -4,8 +4,8 @@ const { saveEnv, restoreEnv } = require('./utils/testSetup'); //env helpers
 
 describe('minLogger', () => { // minLogger
   let savedEnv; //snapshot holder
-  beforeEach(() => { savedEnv = saveEnv(); }); //store env
-  afterEach(() => { restoreEnv(savedEnv); }); //restore env
+  beforeEach(() => { savedEnv = saveEnv(); }); // snapshot env to preserve original settings
+  afterEach(() => { restoreEnv(savedEnv); }); // restore to avoid env leakage between tests
 
   test('logWarn respects LOG_LEVEL warn', () => { //warn should log
     process.env.LOG_LEVEL = 'warn'; //set level

--- a/__tests__/missingEnv.test.js
+++ b/__tests__/missingEnv.test.js
@@ -11,7 +11,7 @@ let axiosMock; //axios adapter to intercept HTTP calls during require
 
 describe('throwIfMissingEnvVars', () => { //describe missing env block
   beforeAll(() => { //setup before tests
-    savedEnv = saveEnv(); //snapshot env //(using util)
+    savedEnv = saveEnv(); // save starting env so we can restore and keep suites isolated
     delete process.env.GOOGLE_API_KEY; //clear key
     delete process.env.GOOGLE_CX; //clear cx
     process.env.OPENAI_TOKEN = 'token'; //set token for qerrors
@@ -21,7 +21,7 @@ describe('throwIfMissingEnvVars', () => { //describe missing env block
   });
 
   afterAll(() => { //restore env vars
-    restoreEnv(savedEnv); //restore full env //(using util)
+    restoreEnv(savedEnv); // restore original env so later suites start clean
   });
 
   test('module throws when env vars missing', () => { //test thrown error on require

--- a/__tests__/parseStringVar.test.js
+++ b/__tests__/parseStringVar.test.js
@@ -26,12 +26,12 @@ describe('parseStringVar', () => { // parseStringVar
         ({ parseStringVar, validateEnvVar } = require('../lib/envValidator')); //load functions under test
         ({ saveEnv, restoreEnv } = require('./utils/testSetup')); //reload helpers using mocked debug utils
 
-        savedEnv = saveEnv(); //capture current env using util
+        savedEnv = saveEnv(); // snapshot env so later tests run with their own settings
         jest.clearAllMocks(); //reset mocks
     });
 
     afterEach(() => {
-        restoreEnv(savedEnv); //restore env after each test
+        restoreEnv(savedEnv); // restore original env to avoid cross-test interference
     });
 
     describe('basic string parsing', () => { // basic string parsing
@@ -147,12 +147,12 @@ describe('validateEnvVar', () => { // validateEnvVar
     let savedEnv; //env snapshot for restore
 
     beforeEach(() => {
-        savedEnv = saveEnv(); //store current env
+        savedEnv = saveEnv(); // snapshot env so validation tests start from a known state
         jest.clearAllMocks(); //reset mocks per test
     });
 
     afterEach(() => {
-        restoreEnv(savedEnv); //restore environment
+        restoreEnv(savedEnv); // restore env to keep subsequent tests independent
     });
 
     describe('required variable validation', () => { // required variable validation

--- a/__tests__/perf-analysis.test.js
+++ b/__tests__/perf-analysis.test.js
@@ -8,7 +8,7 @@ describe('perf-analysis script', () => {
   let logSpy;
 
   beforeEach(() => {
-    savedEnv = saveEnv(); //snapshot env for restoration
+    savedEnv = saveEnv(); // capture env so modifications are cleaned up later
     setTestEnv(); //ensure required env vars present
     process.env.CODEX = 'true'; //offline mode for deterministic test
     jest.resetModules(); //reset module cache
@@ -17,7 +17,7 @@ describe('perf-analysis script', () => {
 
   afterEach(() => {
     logSpy.mockRestore(); //restore console.log
-    restoreEnv(savedEnv); //restore original env
+    restoreEnv(savedEnv); // restore env so next test starts clean
   });
 
   test('cachePerformanceTest runs and logs summary', async () => {

--- a/__tests__/rate-limit-analysis.test.js
+++ b/__tests__/rate-limit-analysis.test.js
@@ -7,16 +7,16 @@ describe('rate-limit-analysis script', () => {
   let logSpy;
 
   beforeEach(() => {
-    savedEnv = saveEnv();
-    setTestEnv();
-    process.env.CODEX = 'true';
+    savedEnv = saveEnv(); // snapshot environment so we can revert after test
+    setTestEnv(); //ensure required vars present for script
+    process.env.CODEX = 'true'; //offline mode prevents real API calls
     jest.resetModules();
     logSpy = mockConsole('log');
   });
 
   afterEach(() => {
     logSpy.mockRestore();
-    restoreEnv(savedEnv);
+    restoreEnv(savedEnv); // restore env to original values for next test
   });
 
   test('rateLimitingAnalysis runs and logs completion', async () => {


### PR DESCRIPTION
## Summary
- clarify environment variable preservation in cacheSizeParsing before/after hooks
- explain restoring env in missingEnv setup/teardown
- mention isolation rationale in envUtils hooks
- document env snapshot logic in parseStringVar and envValidator tests
- update hooks across remaining test suites

## Testing
- `npx jest --runInBand --json > /tmp/test.json`
- `jq '.success' /tmp/test.json`
- `jq '.numPassedTests, .numFailedTests' /tmp/test.json`

------
https://chatgpt.com/codex/tasks/task_b_685215cdf4ec8322aa71539e35666934