### PR TITLE
add missing inline comments in test suite

### DIFF
--- a/__tests__/cacheSizeParsing.test.js
+++ b/__tests__/cacheSizeParsing.test.js
@@ -17,8 +17,8 @@ afterEach(() => {
 
 
 test('parses QSERP_MAX_CACHE_SIZE with leading zero as decimal', () => { // parses QSERP_MAX_CACHE_SIZE with leading zero as decimal
-  setTestEnv();
-  process.env.QSERP_MAX_CACHE_SIZE = '08';
+  setTestEnv(); //provide all required env vars for module
+  process.env.QSERP_MAX_CACHE_SIZE = '08'; //value with leading zero should parse as decimal
 
 
   const LRUCacheMock = jest.fn().mockImplementation(() => ({
@@ -36,8 +36,8 @@ test('parses QSERP_MAX_CACHE_SIZE with leading zero as decimal', () => { // pars
 });
 
 test('invalid QSERP_MAX_CACHE_SIZE falls back to default', () => { // non-numeric value uses default
-  setTestEnv();
-  process.env.QSERP_MAX_CACHE_SIZE = '10abc';
+  setTestEnv(); //populate env vars so module loads
+  process.env.QSERP_MAX_CACHE_SIZE = '10abc'; //nonnumeric value should trigger default
 
   const LRUCacheMock = jest.fn().mockImplementation(() => ({
     get: jest.fn(), // placeholder methods for interface compatibility

--- a/__tests__/memory-growth-analysis.test.js
+++ b/__tests__/memory-growth-analysis.test.js
@@ -22,8 +22,8 @@ describe('memory-growth-analysis script', () => {
   });
 
   test('memoryGrowthAnalysis runs and logs completion', async () => {
-    const { memoryGrowthAnalysis } = require('../memory-growth-analysis.js');
-    await expect(memoryGrowthAnalysis()).resolves.toBeUndefined();
+    const { memoryGrowthAnalysis } = require('../memory-growth-analysis.js'); //import script under test
+    await expect(memoryGrowthAnalysis()).resolves.toBeUndefined(); //script resolves with no return value
     const logs = logSpy.mock.calls.map(c => c[0]);
     expect(logs.some(l => l.includes('=== Memory Growth Analysis ==='))).toBe(true); //check start banner
     expect(logs.some(l => l.includes('=== Memory Analysis Complete ==='))).toBe(true); //check completion banner

--- a/__tests__/perf-analysis.test.js
+++ b/__tests__/perf-analysis.test.js
@@ -22,8 +22,8 @@ describe('perf-analysis script', () => {
   });
 
   test('cachePerformanceTest runs and logs summary', async () => {
-    const { cachePerformanceTest } = require('../perf-analysis.js');
-    await expect(cachePerformanceTest()).resolves.toBeUndefined();
+    const { cachePerformanceTest } = require('../perf-analysis.js'); //import script for execution
+    await expect(cachePerformanceTest()).resolves.toBeUndefined(); //script resolves when complete
     const logs = logSpy.mock.calls.map(c => c[0]);
     expect(logs.some(l => l.includes('=== Cache Performance Analysis ==='))).toBe(true); //verify start log
     expect(logs.some(l => l.includes('=== Performance Analysis Complete ==='))).toBe(true); //verify end log

--- a/__tests__/rate-limit-analysis.test.js
+++ b/__tests__/rate-limit-analysis.test.js
@@ -20,8 +20,8 @@ describe('rate-limit-analysis script', () => {
   });
 
   test('rateLimitingAnalysis runs and logs completion', async () => {
-    const { rateLimitingAnalysis } = require('../rate-limit-analysis.js');
-    await expect(rateLimitingAnalysis()).resolves.toBeUndefined();
+    const { rateLimitingAnalysis } = require('../rate-limit-analysis.js'); //import script under test
+    await expect(rateLimitingAnalysis()).resolves.toBeUndefined(); //script completes without returning value
     const logs = logSpy.mock.calls.map(c => c[0]);
     expect(logs.some(l => l.includes('=== Rate Limiting Performance Analysis ==='))).toBe(true); //verify start banner
     expect(logs.some(l => l.includes('=== Rate Limiting Analysis Complete ==='))).toBe(true); //verify completion banner


### PR DESCRIPTION
## Summary
- add inline comments for clarity in cacheSizeParsing test
- document require calls and awaited results in performance analysis tests

## Testing
- `npm test -- -w=1 --silent`

------
https://chatgpt.com/codex/tasks/task_b_6852ec8a640883228714e39c3553eabd