### PR TITLE
Improve error documentation

### DIFF
--- a/lib/errorUtils.js
+++ b/lib/errorUtils.js
@@ -14,12 +14,14 @@
  * 4. Better error correlation and debugging capabilities
  * 
  * DESIGN STRATEGY: Provides factory functions for common error context patterns
- * while maintaining flexibility for module-specific context data.
+ * while maintaining flexibility for module-specific context data. All paths
+ * feed through safeQerrors so sensitive info is sanitized and the API remains
+ * compatible across qerrors versions.
  */
 
-const { safeQerrors } = require('./qerrorsLoader'); //use wrapper so logging never crashes on reporting errors
-const { logStart, logReturn } = require('./logUtils'); //logging utilities for tracing
-const { sanitizeApiKey } = require('./qserp'); //reuse existing helper for mask to avoid duplication
+const { safeQerrors } = require('./qerrorsLoader'); //safe wrapper masks data and handles qerrors version differences
+const { logStart, logReturn } = require('./logUtils'); //trace execution for easier debugging of error flows
+const { sanitizeApiKey } = require('./qserp'); //central sanitizer prevents leaking API keys across modules
 
 /**
  * Creates standardized error context for API/network operations
@@ -33,11 +35,11 @@ const { sanitizeApiKey } = require('./qserp'); //reuse existing helper for mask 
  */
 function createApiErrorContext(operation, details = {}) {
         logStart('createApiErrorContext', operation); //trace start with operation
-        const context = { //build standardized object
-                category: 'api_error', //identify error category
-                operation, //operation description
-                timestamp: new Date().toISOString(), //timestamp for correlation
-                ...details //spread caller-provided details
+        const context = { //construct block consumed by safeQerrors for structured reporting
+                category: 'api_error', //categorize API failures for dashboards
+                operation, //include caller's description for clarity
+                timestamp: new Date().toISOString(), //timestamp allows cross-version compatibility when logs merge
+                ...details //allow caller provided fields without losing structure
         };
         logReturn('createApiErrorContext', context); //trace resulting object
         return context; //return context for reporting
@@ -55,11 +57,11 @@ function createApiErrorContext(operation, details = {}) {
  */
 function createConfigErrorContext(operation, details = {}) {
         logStart('createConfigErrorContext', operation); //trace start with operation
-        const context = {
-                category: 'config_error', //categorize configuration errors
-                operation,
-                timestamp: new Date().toISOString(), //timestamp for consistency
-                ...details
+        const context = { //structured block for config failure analysis via qerrors
+                category: 'config_error', //explicit label aids log filtering tools
+                operation, //operation name clarifies the failing validation
+                timestamp: new Date().toISOString(), //timestamp keeps logs consistent across environments
+                ...details //caller details merged for compatibility with old code
         };
         logReturn('createConfigErrorContext', context); //trace result object
         return context; //return constructed context
@@ -77,11 +79,11 @@ function createConfigErrorContext(operation, details = {}) {
  */
 function createUtilityErrorContext(operation, details = {}) {
         logStart('createUtilityErrorContext', operation); //trace start with operation
-        const context = {
-                category: 'utility_error', //identify generic utility errors
-                operation,
-                timestamp: new Date().toISOString(), //time of occurrence
-                ...details
+        const context = { //format for generalized helper failures reported via safeQerrors
+                category: 'utility_error', //allows dashboards to group helper issues
+                operation, //operation name clarifies failing helper
+                timestamp: new Date().toISOString(), //consistent time field for compatibility with other contexts
+                ...details //spread details for structured logging without breaking callers
         };
         logReturn('createUtilityErrorContext', context); //trace result context
         return context; //return standardized object
@@ -102,14 +104,14 @@ function createUtilityErrorContext(operation, details = {}) {
 async function reportError(error, message, context = {}, customDetails = {}) {
         logStart('reportError', message); //trace message being reported
         try {
-                const enrichedContext = {
-                        errorType: error.name || 'Error', //standardize error name
+                const enrichedContext = { //compile structured fields for qerrors ingestion
+                        errorType: error.name || 'Error', //normalizes error names for dashboards
                         errorMessage: error.message,
                         stack: error.stack,
                         ...context,
                         ...customDetails
-                };
-                const result = await safeQerrors(error, message, enrichedContext); //capture result from safeQerrors
+                }
+                const result = await safeQerrors(error, message, enrichedContext); //safeQerrors masks keys and handles library differences
                 if (result === false) { //check if reporting failed as indicated by safeQerrors
                         logReturn('reportError', 'failure'); //trace failure branch for log analysis
                         return false; //propagate failure to caller
@@ -136,11 +138,11 @@ async function reportError(error, message, context = {}, customDetails = {}) {
  */
 function createCacheErrorContext(operation, details = {}) {
         logStart('createCacheErrorContext', operation); //trace cache operation
-        const context = {
-                category: 'cache_error', //label cache-related issue
-                operation,
-                timestamp: new Date().toISOString(), //time for log correlation
-                ...details
+        const context = { //context used by safeQerrors for cache layer issues
+                category: 'cache_error', //separate category ensures compatibility with existing metrics
+                operation, //operation indicates get/set failure
+                timestamp: new Date().toISOString(), //timestamp aligns with other builders for structured logs
+                ...details //spread for optional fields without breaking callers
         };
         logReturn('createCacheErrorContext', context); //trace resulting object
         return context; //return standardized context
@@ -158,11 +160,11 @@ function createCacheErrorContext(operation, details = {}) {
  */
 function createValidationErrorContext(operation, details = {}) {
         logStart('createValidationErrorContext', operation); //trace start
-        const context = {
-                category: 'validation_error', //category label for validators
-                operation,
-                timestamp: new Date().toISOString(), //timestamp for trace
-                ...details
+        const context = { //context keeps validation failures consistent with other builders
+                category: 'validation_error', //label allows structured metrics across modules
+                operation, //identify failing validation rule for debugging
+                timestamp: new Date().toISOString(), //timestamp ensures compatibility with log parsers
+                ...details //spread to preserve caller specific fields
         };
         logReturn('createValidationErrorContext', context); //trace object
         return context; //return structured context
@@ -177,8 +179,8 @@ function createValidationErrorContext(operation, details = {}) {
  */
 async function reportApiError(error, operation, apiDetails = {}) {
         logStart('reportApiError', operation); //trace operation
-        const context = createApiErrorContext(operation, apiDetails); //build context
-        const result = await reportError(error, `API Error: ${operation}`, context); //await delegate reporting
+        const context = createApiErrorContext(operation, apiDetails); //build context for structured report
+        const result = await reportError(error, `API Error: ${operation}`, context); //reportError ensures sanitized output
         logReturn('reportApiError', result); //trace result
         return result; //return outcome of reportError
 }
@@ -192,8 +194,8 @@ async function reportApiError(error, operation, apiDetails = {}) {
  */
 async function reportConfigError(error, operation, configDetails = {}) {
         logStart('reportConfigError', operation); //trace operation
-        const context = createConfigErrorContext(operation, configDetails); //build context
-        const result = await reportError(error, `Configuration Error: ${operation}`, context); //await delegate
+        const context = createConfigErrorContext(operation, configDetails); //build context for structured report
+        const result = await reportError(error, `Configuration Error: ${operation}`, context); //reportError sanitizes details
         logReturn('reportConfigError', result); //trace result
         return result; //propagate
 }
@@ -207,19 +209,19 @@ async function reportConfigError(error, operation, configDetails = {}) {
  */
 async function reportValidationError(error, operation, validationDetails = {}) {
         logStart('reportValidationError', operation); //trace operation
-        const context = createValidationErrorContext(operation, validationDetails); //build context
-        const result = await reportError(error, `Validation Error: ${operation}`, context); //await delegate
+        const context = createValidationErrorContext(operation, validationDetails); //build context for structured log
+        const result = await reportError(error, `Validation Error: ${operation}`, context); //reportError handles sanitization
         logReturn('reportValidationError', result); //trace result
         return result; //return result
 }
 
 /**
  * Module exports
- * 
+ *
  * These utilities provide consistent error reporting patterns that replace
- * the scattered qerrors calls throughout the codebase. The functions are
- * designed to work with existing error handling while providing better
- * structure and consistency.
+ * the scattered qerrors calls throughout the codebase. Each function funnels
+ * data through safeQerrors so API keys are sanitized and logging remains
+ * compatible with older qerrors versions.
  */
 module.exports = {
         createApiErrorContext,

--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -7,16 +7,17 @@
  * 
  * CONSOLIDATION RATIONALE: The pattern of wrapping qerrors calls in try-catch blocks
  * appears in lib/qserp.js, lib/envUtils.js, and lib/minLogger.js. Centralizing this
- * pattern provides consistent error handling behavior across all modules.
+ * pattern provides consistent error handling behavior across all modules while ensuring
+ * sanitized logs and compatibility with varying qerrors export styles.
  */
 
-const { logStart, logReturn } = require('./logUtils'); //import standardized logging utilities
-const { DEBUG } = require('./debugUtils'); //import debug flag to gate verbose logs
-const { logError } = require('./minLogger'); //import error logging utility
-const defaultApiKey = process.env.GOOGLE_API_KEY; //capture once to sanitize log messages consistently
+const { logStart, logReturn } = require('./logUtils'); //standardized logging aids structured error tracing
+const { DEBUG } = require('./debugUtils'); //debug flag gates verbose output to keep logs lean
+const { logError } = require('./minLogger'); //fallback logger for when qerrors fails
+const defaultApiKey = process.env.GOOGLE_API_KEY; //cache key so sanitization is consistent across reloads
 
 // Sanitizes strings by masking the API key wherever it appears
-function sanitizeApiKey(text) { //prevent leaking key values in logs
+function sanitizeApiKey(text) { //central sanitization avoids leaking credentials in logs
         let result; //value after sanitization for return logging
         let sanitizedInput; //intermediate mutated string
         const applyPatterns = (str, key) => { //helper masks one key
@@ -83,19 +84,19 @@ function sanitizeApiKey(text) { //prevent leaking key values in logs
  * error reporting silently stops working.
  */
 function loadQerrors() {
-        logStart('loadQerrors', 'qerrors module'); //log start before require
+        logStart('loadQerrors', 'qerrors module'); //trace attempt so any failure shows source
         try {
-                const mod = require('qerrors'); //import installed module once here to catch load errors early
+                const mod = require('qerrors'); //import installed module once so compatibility checks run early
                 
                 // Resolve function from various possible export patterns
                 // Updated for qerrors v1.2.3+ which exports an object with named functions
                 // Priority: mod.qerrors (v1.2.3+), mod (direct function), mod.default (ES6)
-                const qerrors = mod.qerrors || (typeof mod === 'function' ? mod : mod.default); //resolve exported function
+                const qerrors = mod.qerrors || (typeof mod === 'function' ? mod : mod.default); //handle multiple export patterns for version compatibility
                 
                 // Validate that we successfully extracted a callable function
                 // This prevents runtime errors when other modules try to call qerrors()
                 if (typeof qerrors !== 'function') { //verify resolved export is callable
-                        throw new Error('qerrors module does not export a callable function'); //throw explicit error when export invalid
+                        throw new Error('qerrors module does not export a callable function'); //fail fast when qerrors missing
                 }
                 
                 logReturn('loadQerrors', qerrors.name); //log selected function name
@@ -103,7 +104,7 @@ function loadQerrors() {
         } catch (error) {
                 // Log the failure for debugging but re-throw to fail fast
                 // This ensures that module loading issues are immediately visible
-                console.error(error); //log loader failure
+                console.error(error); //log loader failure without sanitization because no key expected
                 throw error; //re-throw loader error
         }
 }
@@ -129,13 +130,13 @@ function loadQerrors() {
  * @returns {Promise<*>} - Result from qerrors or false on failure
  */
 async function safeQerrors(error, context, additionalData = {}) { //async to return awaited qerrors result
-        const cleanCtx = sanitizeApiKey(context); //mask api key before logging context
-        logStart('safeQerrors', cleanCtx); //avoid leaking raw context value
+        const cleanCtx = sanitizeApiKey(context); //mask key to maintain log hygiene
+        logStart('safeQerrors', cleanCtx); //trace sanitized context for debugging
 
         const safeMsg = String(error?.message || error).replace(/\n/g, ' '); //newline sanitize for later logs
         
         try {
-                const qerrors = loadQerrors();
+                const qerrors = loadQerrors(); //ensure latest module with compatibility support
                 
                 // Ensure error is an Error object for qerrors v1.2.3+ compatibility
                 const errorObj = error instanceof Error ? error : new Error(safeMsg); //use sanitized message when wrapping
@@ -180,14 +181,14 @@ function createCompatibleQerrors() {
 
         const compatibleQerrors = function compatibleQerrors(error, context, additionalData = {}) {
                 logStart('compatibleQerrors', context); //trace call context
-                const errorObj = error instanceof Error ? error : new Error(String(error)); //ensure Error instance
+                const errorObj = error instanceof Error ? error : new Error(String(error)); //convert to maintain compatibility with qerrors >=1.2.3
                 const result = qerrors(errorObj, context, additionalData); //delegate to loaded qerrors
                 logReturn('compatibleQerrors', result); //trace result for debugging
                 return result; //propagate outcome
         };
 
         logReturn('createCompatibleQerrors', 'function'); //trace wrapper creation
-        return compatibleQerrors; //return wrapped function
+        return compatibleQerrors; //return wrapped function for callers expecting older API
 }
 
 /**
@@ -201,14 +202,14 @@ module.exports = function() {
         logStart('defaultExport', 'init'); //trace loader wrapper start
         const wrapped = createCompatibleQerrors(); //generate wrapper so consumers get consistent API
         logReturn('defaultExport', 'function'); //trace wrapper created
-        return wrapped; //return new wrapper
+        return wrapped; //return new wrapper for backward compatibility and sanitized logging
 };
 
 // Named exports for enhanced functionality
 module.exports.loadQerrors = loadQerrors;       // Direct loader access
-module.exports.safeQerrors = safeQerrors;       // Safe wrapper with fallback
+module.exports.safeQerrors = safeQerrors;       //safeQerrors exposes sanitization logic for callers
 module.exports.createCompatible = createCompatibleQerrors; // Explicit wrapper creation
-module.exports.sanitizeApiKey = sanitizeApiKey; // Export sanitizer for testing
+module.exports.sanitizeApiKey = sanitizeApiKey; //export sanitizer so tests verify log hygiene
 
 // Maintain backward compatibility with existing imports
 module.exports.default = module.exports;


### PR DESCRIPTION
## Summary
- refine logging comments in error utils
- clarify sanitization and compatibility in qerrors loader

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6853026a72fc83229a245a7c38794a9e