### PR TITLE
Add inline comments for logging fallbacks

### DIFF
--- a/lib/minLogger.js
+++ b/lib/minLogger.js
@@ -27,8 +27,8 @@ const util = require('util'); //use util.inspect when JSON.stringify fails
 
 // Check if info level logging is allowed for trace messages //rationale: avoid noisy logs when not needed
 function canLogInfo() {
-        const envLvl = String(process.env.LOG_LEVEL || 'info').trim().toLowerCase(); //normalize env var trimming spaces
-        return envLvl === 'info'; //only true when env requests info verbosity
+        const envLvl = String(process.env.LOG_LEVEL || 'info').trim().toLowerCase(); //normalize env var once per call for reliability
+        return envLvl === 'info'; //only true when env requests info verbosity so debug traces stay quiet otherwise
 }
 
 /**

--- a/lib/qerrorsLoader.js
+++ b/lib/qerrorsLoader.js
@@ -161,7 +161,7 @@ async function safeQerrors(error, context, additionalData = {}) { //async to ret
                         console.error('Context:', sanitizeApiKey(context)); //sanitize context for console
                 }
                 logReturn('safeQerrors', 'failed');
-                return false;
+                return false; //signal to caller that even fallback logging failed, preventing chained errors
         }
 }
 


### PR DESCRIPTION
## Summary
- document why `canLogInfo` checks the env var
- clarify the fallback return in `safeQerrors`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685302820d5c8322890e63a315a812ae