### PR TITLE
Add rationale comments for env utils

### DIFF
--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -42,7 +42,7 @@ function calcMissing(varArr) {
        } catch (err) {
                void Promise.resolve(safeQerrors(err, 'calcMissing error', { varArr })).catch(() => {}); //fire-and-forget to avoid blocking sync API
                if (DEBUG) { logReturn('calcMissing', []); } //trace fallback result
-               return []; //fallback to empty array on error
+               return []; //error encountered -> treat as no vars missing
        }
 }
 
@@ -59,10 +59,10 @@ function calcMissing(varArr) {
 function getMissingEnvVars(varArr) {
        if (DEBUG) { logStart('getMissingEnvVars', varArr); } //log start only when debug enabled
 
-       const missingArr = calcMissing(varArr); //sync filter with error handling
+       const missingArr = calcMissing(varArr); //throws TypeError when input not array
 
        if (DEBUG) { logReturn('getMissingEnvVars', missingArr); } //log result only when debug enabled
-       return missingArr; //return filtered array or fallback
+       return missingArr; //array of missing names, empty when all present
 }
 
 /**
@@ -79,7 +79,7 @@ function getMissingEnvVars(varArr) {
 function throwIfMissingEnvVars(varArr) {
        if (DEBUG) { logStart('throwIfMissingEnvVars', varArr); } //log start only when debug enabled
 
-       const missingEnvVars = calcMissing(varArr); //sync detection with safe error handling
+       const missingEnvVars = calcMissing(varArr); //calcMissing may throw TypeError for bad input
 
        if (missingEnvVars.length > 0) {
                // Construct comprehensive error message listing all missing variables
@@ -103,7 +103,7 @@ function throwIfMissingEnvVars(varArr) {
        }
 
        if (DEBUG) { logReturn('throwIfMissingEnvVars', missingEnvVars); } //log result only when debug enabled
-       return missingEnvVars; //return array when all vars present
+       return missingEnvVars; //empty array means all required vars exist
 }
 
 /**
@@ -135,9 +135,9 @@ function warnIfMissingEnvVars(varArr, customMessage = '') {
                 logWarn(warningMessage); //use minLogger instead of console.warn
        }
 
-       const result = missingEnvVars.length === 0; //determine if any vars missing //(compute boolean)
+       const result = missingEnvVars.length === 0; //true when no optional vars missing
        if (DEBUG) { logReturn('warnIfMissingEnvVars', result); } //log result only when debug enabled
-       return result; //inform caller if all vars present //(boolean instead of array)
+       return result; //false signals optional vars absent but execution continues
 }
 
 /**

--- a/lib/envValidator.js
+++ b/lib/envValidator.js
@@ -36,12 +36,12 @@ function parseIntWithBounds(varName, defaultValue, minValue, maxValue) {
     // VALIDATION UPDATE: ensure entire value is numeric before parsing to prevent partial parsing of values like '10abc'
     const rawString = (process.env[varName] || '').trim(); //trim to remove accidental spaces
     const numericMatch = /^-?\d+$/.test(rawString); //regex now only accepts whole numbers to reject decimals
-    const envValue = numericMatch ? parseInt(rawString, 10) : NaN; //parse only if valid
+    const envValue = numericMatch ? parseInt(rawString, 10) : NaN; //non digits produce NaN -> default used
     const rawValue = !isNaN(envValue) ? envValue : defaultValue; //retain default when NaN
     
     // Apply bounds checking for security and stability
     // Math.max ensures value >= minValue, Math.min ensures value <= maxValue
-    const validatedValue = Math.max(minValue, Math.min(rawValue, maxValue));
+    const validatedValue = Math.max(minValue, Math.min(rawValue, maxValue)); //clamps value within allowed bounds
     
     debugExit('parseIntWithBounds', validatedValue);
     return validatedValue;
@@ -67,7 +67,7 @@ function parseBooleanVar(varName, defaultValue = false) {
     }
     
     // Case-insensitive true detection
-    const isTrue = /^true$/i.test(rawValue.trim()); //accepts TRUE/True/ true etc.
+    const isTrue = /^true$/i.test(rawValue.trim()); //any non-'true' value evaluates as false
     
     debugExit('parseBooleanVar', isTrue);
     return isTrue;
@@ -87,18 +87,18 @@ function parseBooleanVar(varName, defaultValue = false) {
 function parseStringVar(varName, defaultValue = '', maxLength = 0) {
     debugEntry('parseStringVar', `${varName}, default: ${defaultValue}, maxLength: ${maxLength}`);
     
-    const rawValue = process.env[varName] || defaultValue; //fallback ensures defined string
+    const rawValue = process.env[varName] || defaultValue; //use default when var missing
     const trimmedValue = rawValue.trim(); //normalize spacing for validation
     
     // Apply length constraints for security
     if (maxLength > 0 && trimmedValue.length > maxLength) {
-        const truncatedValue = trimmedValue.substring(0, maxLength);
+        const truncatedValue = trimmedValue.substring(0, maxLength); //excess characters removed
         debugExit('parseStringVar', `truncated to ${maxLength} chars`);
         return truncatedValue;
     }
     
     debugExit('parseStringVar', `length: ${trimmedValue.length}`);
-    return trimmedValue;
+    return trimmedValue; //return normalized string to caller
 }
 
 /**
@@ -119,13 +119,13 @@ function validateEnvVar(varName, required = true) {
     const hasValue = exists && process.env[varName].trim().length > 0; //treat blanks as missing
     
     if (required && !hasValue) {
-        const error = new Error(`Required environment variable ${varName} is missing or empty`);
+        const error = new Error(`Required environment variable ${varName} is missing or empty`); //fail fast when mandatory var blank
         debugExit('validateEnvVar', 'missing required variable');
-        throw error;
+        throw error; //caller must handle this hard failure
     }
     
     debugExit('validateEnvVar', hasValue ? 'valid' : 'optional missing');
-    return hasValue;
+    return hasValue; //true when var present or optional, false when optional missing
 }
 
 /**


### PR DESCRIPTION
## Summary
- clarify numeric fallback behavior in `parseIntWithBounds`
- refine boolean parsing comment in `parseBooleanVar`
- document defaults and truncation in `parseStringVar`
- explain failure handling in `validateEnvVar`
- note error handling in `calcMissing`
- document return semantics for environment variable utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6853025edf508322beb27ea002355e2d