### PR TITLE
Expand debug utils docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ The `lib/debugUtils.js` module consolidates all logging helpers. It now
 re-exports `logStart` and `logReturn` to maintain compatibility, so
 `lib/logUtils.js` is deprecated and merely re-exports these functions.
 
+Use `debugLog` to print quick messages only when debugging is enabled. The
+`createTracer` helper builds an object with `entry` and `exit` methods to reduce
+boilerplate when a single function requires multiple trace points.
+
 Example usage:
 
 ```javascript
@@ -263,6 +267,19 @@ function runTask() {
   debugEntry('runTask');
   // task logic
   debugExit('runTask');
+}
+```
+
+`createTracer` example:
+
+```javascript
+const { createTracer } = require('./lib/debugUtils');
+
+function runTask() {
+  const trace = createTracer('runTask');
+  trace.entry();
+  // task logic
+  trace.exit();
 }
 ```
 


### PR DESCRIPTION
## Summary
- explain `debugLog` and `createTracer` in README
- show how to use `createTracer`

## Testing
- `npx jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_b_6853f7d987d483229801e2fb01acf1f4